### PR TITLE
Fix exception and prevent recalculations if not needed

### DIFF
--- a/Maui.DataGrid/DataGridRow.cs
+++ b/Maui.DataGrid/DataGridRow.cs
@@ -103,7 +103,7 @@ internal sealed class DataGridRow : Grid
 
     private void UpdateBackgroundColor()
     {
-        _hasSelected = DataGrid.SelectedItem == RowContext;
+        _hasSelected = DataGrid?.SelectedItem == RowContext;
         var actualIndex = DataGrid?.InternalItems?.IndexOf(BindingContext) ?? -1;
         if (actualIndex > -1)
         {

--- a/Maui.DataGrid/DataGridRowTemplateSelector.cs
+++ b/Maui.DataGrid/DataGridRowTemplateSelector.cs
@@ -1,5 +1,7 @@
 ﻿namespace Maui.DataGrid;
 
+using Maui.DataGrid.Utils;
+
 internal class DataGridRowTemplateSelector : DataTemplateSelector
 {
     private static DataTemplate _dataGridRowTemplate;
@@ -15,13 +17,13 @@ internal class DataGridRowTemplateSelector : DataTemplateSelector
         var dataGrid = (DataGrid)collectionView.Parent.Parent;
         var items = dataGrid.InternalItems;
 
-        _dataGridRowTemplate.SetValue(DataGridRow.DataGridProperty, dataGrid);
-        _dataGridRowTemplate.SetValue(DataGridRow.RowContextProperty, item);
-        _dataGridRowTemplate.SetValue(VisualElement.HeightRequestProperty, dataGrid.RowHeight);
+        _dataGridRowTemplate.SetValueIfNeeded(DataGridRow.DataGridProperty, dataGrid);
+        _dataGridRowTemplate.SetValueIfNeeded(DataGridRow.RowContextProperty, item);
+        _dataGridRowTemplate.SetValueIfNeeded(VisualElement.HeightRequestProperty, dataGrid.RowHeight);
 
         if (items != null)
         {
-            _dataGridRowTemplate.SetValue(DataGridRow.IndexProperty, items.IndexOf(item));
+            _dataGridRowTemplate.SetValueIfNeeded(DataGridRow.IndexProperty, items.IndexOf(item));
         }
 
         return _dataGridRowTemplate;

--- a/Maui.DataGrid/Utils/DataTemplateExtensions.cs
+++ b/Maui.DataGrid/Utils/DataTemplateExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace Maui.DataGrid.Utils;
+
+internal static class DataTemplateExtensions
+{
+    internal static void SetValueIfNeeded(this DataTemplate dataTemplate, BindableProperty property, object newValue)
+    {
+        dataTemplate.Values.TryGetValue(property, out object oldValue);
+        if (newValue != oldValue)
+        {
+            dataTemplate.SetValue(property, newValue);
+        }
+    }
+}


### PR DESCRIPTION
This improves scrolling and prevents an exception on Windows when loading lots of items and then navigating.

The exception this prevents says: "A cycle occurred while laying out the GUI."