### PR TITLE
Use a simpler border and background color strategy

### DIFF
--- a/Maui.DataGrid/DataGrid.xaml
+++ b/Maui.DataGrid/DataGrid.xaml
@@ -4,9 +4,7 @@
       xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
       xmlns:local="clr-namespace:Maui.DataGrid;assembly=Maui.DataGrid"
-      x:Class="Maui.DataGrid.DataGrid"
-      Padding="0"
-      RowSpacing="0">
+      x:Class="Maui.DataGrid.DataGrid">
     <Grid.Resources>
         <ResourceDictionary>
             <local:BoolToSelectionModeConverter x:Key="boolToSelectionMode" />
@@ -16,7 +14,7 @@
         <RowDefinition Height="Auto" />
         <RowDefinition Height="*" />
     </Grid.RowDefinitions>
-    <Grid Grid.Row="0" x:Name="_headerView" RowSpacing="0">
+    <Grid Grid.Row="0" x:Name="_headerView">
         <Grid.Resources>
             <ResourceDictionary>
                 <!--Default Header Style-->
@@ -25,7 +23,6 @@
                     <Setter Property="HorizontalOptions" Value="Center" />
                     <Setter Property="VerticalOptions" Value="Center" />
                     <Setter Property="TextColor" Value="Black" />
-                    <Setter Property="LineBreakMode" Value="WordWrap" />
                 </Style>
                 <Style x:Key="SortIconStyle" TargetType="Polygon">
                     <Setter Property="Aspect" Value="Uniform" />
@@ -35,7 +32,7 @@
             </ResourceDictionary>
         </Grid.Resources>
     </Grid>
-    <RefreshView Grid.Row="1" x:Name="_refreshView" Grid.RowSpan="2" Command="{Binding PullToRefreshCommand, Source={x:Reference self}}" IsRefreshing="{Binding IsRefreshing, Source={x:Reference self}, Mode=TwoWay}">
+    <RefreshView Grid.Row="1" x:Name="_refreshView" Command="{Binding PullToRefreshCommand, Source={x:Reference self}}" IsRefreshing="{Binding IsRefreshing, Source={x:Reference self}, Mode=TwoWay}">
         <CollectionView x:Name="_collectionView" SelectedItem="{Binding SelectedItem, Source={x:Reference self}, Mode=TwoWay}"  SelectionMode="{Binding SelectionEnabled, Source={x:Reference self}, Converter={StaticResource boolToSelectionMode}}" >
             <CollectionView.ItemTemplate>
                 <DataTemplate>

--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -321,11 +321,11 @@ public partial class DataGrid
             propertyChanged: (b, _, n) => ((DataGrid)b)._refreshView.IsRefreshing = (bool)n);
 
     public static readonly BindableProperty BorderThicknessProperty =
-        BindableProperty.Create(nameof(BorderThickness), typeof(Thickness), typeof(DataGrid), new Thickness(1),
+        BindableProperty.Create(nameof(BorderThickness), typeof(double), typeof(DataGrid), (double)1,
             propertyChanged: (b, _, n) =>
             {
-                ((DataGrid)b)._headerView.ColumnSpacing = ((Thickness)n).HorizontalThickness / 2;
-                ((DataGrid)b)._headerView.Padding = ((Thickness)n).HorizontalThickness / 2;
+                ((DataGrid)b)._headerView.ColumnSpacing = ((double)n) / 2;
+                ((DataGrid)b)._headerView.Padding = new Thickness(((double)n) / 2);
             });
 
     public static readonly BindableProperty HeaderBordersVisibleProperty =
@@ -570,9 +570,9 @@ public partial class DataGrid
     /// <summary>
     /// Border thickness for header &amp; each cell
     /// </summary>
-    public Thickness BorderThickness
+    public double BorderThickness
     {
-        get => (Thickness)GetValue(BorderThicknessProperty);
+        get => (double)GetValue(BorderThicknessProperty);
         set => SetValue(BorderThicknessProperty, value);
     }
 
@@ -701,7 +701,7 @@ public partial class DataGrid
             column.SortingIcon.Style = SortIconStyle ?? (Style)_headerView.Resources["SortIconStyle"];
             column.SortingIconContainer.HeightRequest = HeaderHeight * 0.35;
             column.SortingIconContainer.WidthRequest = HeaderHeight * 0.35;
-      
+
             var grid = new Grid
             {
                 ColumnSpacing = 0,
@@ -746,8 +746,7 @@ public partial class DataGrid
         _headerView.ColumnDefinitions.Clear();
         _sortingOrders.Clear();
 
-        _headerView.Padding = new(BorderThickness.Left, BorderThickness.Top, BorderThickness.Right, 0);
-        _headerView.ColumnSpacing = BorderThickness.HorizontalThickness / 2;
+        _headerView.ColumnSpacing = BorderThickness;
 
         if (Columns != null)
         {
@@ -758,8 +757,11 @@ public partial class DataGrid
                 _headerView.ColumnDefinitions.Add(new() { Width = col.Width });
 
                 var cell = GetHeaderViewForColumn(col, i);
+
                 cell.SetBinding(BackgroundColorProperty, new Binding(nameof(HeaderBackground), source:this));
+
                 _headerView.Children.Add(cell);
+
                 Grid.SetColumn(cell, i);
 
                 _sortingOrders.Add(i, SortingOrder.None);

--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -321,7 +321,7 @@ public partial class DataGrid
             propertyChanged: (b, _, n) => ((DataGrid)b)._refreshView.IsRefreshing = (bool)n);
 
     public static readonly BindableProperty BorderThicknessProperty =
-        BindableProperty.Create(nameof(BorderThickness), typeof(double), typeof(DataGrid), (double)1,
+        BindableProperty.Create(nameof(BorderThickness), typeof(double), typeof(DataGrid), (double)2,
             propertyChanged: (b, _, n) =>
             {
                 if (b is DataGrid self)

--- a/Maui.DataGrid/DataGridColumn.cs
+++ b/Maui.DataGrid/DataGridColumn.cs
@@ -18,7 +18,6 @@ public class DataGridColumn : BindableObject, IDefinition
             Content = SortingIcon,
             HorizontalOptions = LayoutOptions.Center,
             VerticalOptions = LayoutOptions.Center,
-            Margin = 0
         };
     }
 

--- a/Maui.DataGrid/DataGridRow.cs
+++ b/Maui.DataGrid/DataGridRow.cs
@@ -1,5 +1,6 @@
 ﻿namespace Maui.DataGrid;
 
+using Microsoft.Maui.Controls.Shapes;
 using Utils;
 
 internal sealed class DataGridRow : Grid
@@ -42,11 +43,13 @@ internal sealed class DataGridRow : Grid
     private void CreateView()
     {
         UpdateBackgroundColor();
-        ColumnSpacing = DataGrid.BorderThickness / 2;
-        Padding = new Thickness(DataGrid.BorderThickness / 2);
 
-        foreach (var col in DataGrid.Columns)
+        ColumnSpacing = DataGrid.BorderThickness;
+        Margin = new Thickness(0, 0, 0, DataGrid.BorderThickness);
+
+        for (int i = 0; i < DataGrid.Columns.Count; i++)
         {
+            DataGridColumn col = DataGrid.Columns[i];
             ColumnDefinitions.Add(new ColumnDefinition { Width = col.Width });
 
             if (col.CellTemplate?.CreateContent() is View cell)
@@ -62,8 +65,6 @@ internal sealed class DataGridRow : Grid
                 cell = new Label
                 {
                     TextColor = TextColor,
-                    VerticalOptions = LayoutOptions.Fill,
-                    HorizontalOptions = LayoutOptions.Fill,
                     VerticalTextAlignment = col.VerticalContentAlignment.ToTextAlignment(),
                     HorizontalTextAlignment = col.HorizontalContentAlignment.ToTextAlignment(),
                     LineBreakMode = col.LineBreakMode
@@ -76,17 +77,14 @@ internal sealed class DataGridRow : Grid
                     new Binding(DataGrid.FontFamilyProperty.PropertyName, BindingMode.Default, source: DataGrid));
             }
 
-            var border = new Border
+            var border = new ContentView
             {
-                BackgroundColor = Colors.Transparent,
                 Content = cell,
-                Stroke = new SolidColorBrush(DataGrid.BorderColor),
-                StrokeThickness = DataGrid.BorderThickness,
                 HeightRequest = DataGrid.RowHeight
             };
 
             Children.Add(border);
-            SetColumn((BindableObject)border, DataGrid.Columns.IndexOf(col));
+            SetColumn((BindableObject)border, i);
         }
     }
 
@@ -96,13 +94,13 @@ internal sealed class DataGridRow : Grid
         var actualIndex = DataGrid?.InternalItems?.IndexOf(BindingContext) ?? -1;
         if (actualIndex > -1)
         {
-            BackgroundColor =
+            var backgroundColor =
                 DataGrid.SelectionEnabled && DataGrid.SelectedItem != null && DataGrid.SelectedItem == BindingContext
                     ? DataGrid.ActiveRowColor
                     : DataGrid.RowsBackgroundColorPalette.GetColor(actualIndex, BindingContext);
             TextColor = DataGrid.RowsTextColorPalette.GetColor(actualIndex, BindingContext);
 
-            ChangeColor(BackgroundColor, TextColor);
+            ChangeColor(backgroundColor, TextColor);
         }
     }
 
@@ -110,11 +108,12 @@ internal sealed class DataGridRow : Grid
     {
         foreach (var child in Children)
         {
-            if (child is Border border)
+            if (child is View view)
             {
-                if (border.Content is Label label)
+                view.BackgroundColor = backgroundColor;
+
+                if (view is ContentView contentView && contentView.Content is Label label)
                 {
-                    label.BackgroundColor = backgroundColor;
                     label.TextColor = textColor;
                 }
             }

--- a/Maui.DataGrid/Utils/MathUtil.cs
+++ b/Maui.DataGrid/Utils/MathUtil.cs
@@ -1,0 +1,12 @@
+﻿namespace Maui.DataGrid.Utils;
+
+internal static class MathUtil
+{
+    internal static int RoundUp(double input)
+    {
+        if (input < 1)
+            return 1;
+        else
+            return (int)Math.Round(input);
+    }
+}


### PR DESCRIPTION
Sometimes I notice that the borders aren't always showing up for me on some columns.

This made me look into the logic, and I noticed that it was more confusing than it needed to be.

The BorderColor was used as the BackgroundColor.

This PR changes it so that the background color of the rows is indeed the BackgroundColor, and the border color is indeed the BorderColor.

In order to accomplish this, I unfortunately needed to change the data type of the BorderThickness to a double, to match the data type used on Border's StrokeThickness.  Allowing this to work with Thickness would be a good change, but I don't see how to do it. Feel free to edit this.

One level of nesting with the ContentView was removed, but then another level with the Border was added, which nets out to about even.

This all makes much more sense to me.