### PR TITLE
Bind LineBreakMode to DataGridColumn

### DIFF
--- a/Maui.DataGrid/DataGridColumn.cs
+++ b/Maui.DataGrid/DataGridColumn.cs
@@ -51,6 +51,10 @@ public class DataGridColumn : BindableObject, IDefinition
     public static readonly BindableProperty CellTemplateProperty =
         BindableProperty.Create(nameof(CellTemplate), typeof(DataTemplate), typeof(DataGridColumn));
 
+    public static readonly BindableProperty LineBreakModeProperty =
+        BindableProperty.Create(nameof(LineBreakMode), typeof(LineBreakMode), typeof(DataGridColumn),
+            LineBreakMode.WordWrap);
+
     public static readonly BindableProperty HorizontalContentAlignmentProperty =
         BindableProperty.Create(nameof(HorizontalContentAlignment), typeof(LayoutOptions), typeof(DataGridColumn),
             LayoutOptions.Center);
@@ -143,6 +147,15 @@ public class DataGridColumn : BindableObject, IDefinition
 
     internal Polygon SortingIcon { get; set; }
     internal Label HeaderLabel { get; set; }
+
+    /// <summary>
+    /// LineBreakModeProperty for the text. WordWrap by default.
+    /// </summary>
+    public LineBreakMode LineBreakMode
+    {
+        get => (LineBreakMode)GetValue(LineBreakModeProperty);
+        set => SetValue(LineBreakModeProperty, value);
+    }
 
     /// <summary>
     /// Horizontal alignment of the cell content 

--- a/Maui.DataGrid/DataGridRow.cs
+++ b/Maui.DataGrid/DataGridRow.cs
@@ -65,7 +65,7 @@ internal sealed class DataGridRow : Grid
                     HorizontalOptions = LayoutOptions.Fill,
                     VerticalTextAlignment = col.VerticalContentAlignment.ToTextAlignment(),
                     HorizontalTextAlignment = col.HorizontalContentAlignment.ToTextAlignment(),
-                    LineBreakMode = LineBreakMode.WordWrap
+                    LineBreakMode = col.LineBreakMode
                 };
                 cell.SetBinding(Label.TextProperty,
                     new Binding(col.PropertyName, BindingMode.Default, stringFormat: col.StringFormat));


### PR DESCRIPTION
Self-explanatory. Could be a good prep for allowing to bind on ItemSizingStrategy, which can affect performance, but also can help ensure consistency. If you set WordWrap to off then you can ensure all rows are the same height.

But with variable-height rows, you cannot increase performance that way.