### PR TITLE
don't attach or invoke refreshing events if refreshing not enabled

### DIFF
--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -654,13 +654,16 @@ public partial class DataGrid
             }
         }
 
-        if (Parent is null)
+        if (RefreshingEnabled)
         {
-            _refreshView.Refreshing -= OnRefreshing;
-        }
-        else
-        {
-            _refreshView.Refreshing += OnRefreshing;
+            if (Parent is null)
+            {
+                _refreshView.Refreshing -= OnRefreshing;
+            }
+            else
+            {
+                _refreshView.Refreshing += OnRefreshing;
+            }
         }
     }
 

--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -289,14 +289,14 @@ public partial class DataGrid
 
     public static readonly BindableProperty RefreshingEnabledProperty =
     BindableProperty.Create(nameof(RefreshingEnabled), typeof(bool), typeof(DataGrid), true,
-        propertyChanged: (b, _, n) =>
-        {
-            var self = (DataGrid)b;
-            if (n is bool refreshingEnabled)
+            propertyChanged: (b, _, n) =>
             {
-                self.PullToRefreshCommand?.CanExecute(refreshingEnabled);
-            }
-        });
+                var self = (DataGrid)b;
+                if (n is bool refreshingEnabled)
+                {
+                    self.PullToRefreshCommand?.CanExecute(() => refreshingEnabled);
+                }
+            });
 
     public static readonly BindableProperty PullToRefreshCommandProperty =
         BindableProperty.Create(nameof(PullToRefreshCommand), typeof(ICommand), typeof(DataGrid), null,

--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -305,12 +305,10 @@ public partial class DataGrid
                 var self = (DataGrid)b;
                 if (n == null)
                 {
-                    self._refreshView.IsEnabled = false;
                     self._refreshView.Command = null;
                 }
                 else
                 {
-                    self._refreshView.IsEnabled = true;
                     self._refreshView.Command = n as ICommand;
                     self._refreshView.Command.CanExecute(self.RefreshingEnabled);
                 }


### PR DESCRIPTION
These are some minor helpful changes.

Refreshing is actually still always showing the indicator for me on Windows, despite that these changes seem like they should work. The PullToRefreshCommand will not execute if RefreshingEnabled is false, but the indicator makes it seem like it is.

Can't use IsEnabled on the RefreshView since that would disable everything inside of it, so I removed those line, and none of the other bindable properties on the RefreshView seem promising.

Changing the default RefreshingEnabled value to false also does nothing

Thoughts? The useless indicator was always active before, so there was no regression on this at any point. But it would be nice to fix it.

Possibly a bug in MAUI itself. The animation should respect the canExecute command.