### PR TITLE
Prevent sorting on non-sortable columns

### DIFF
--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -639,7 +639,6 @@ public partial class DataGrid
     protected override void OnParentSet()
     {
         base.OnParentSet();
-        InitHeaderView();
 
         if (SelectionEnabled)
         {
@@ -669,7 +668,7 @@ public partial class DataGrid
     protected override void OnBindingContextChanged()
     {
         base.OnBindingContextChanged();
-        SetColumnsBindingContext();
+        InitHeaderView();
     }
 
     private void OnRefreshing(object sender, EventArgs e)

--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -54,14 +54,19 @@ public partial class DataGrid
         var column = Columns[sortData.Index];
         var order = sortData.Order;
 
+        if (column.PropertyName == null)
+        {
+            throw new InvalidOperationException($"Please set the {nameof(column.PropertyName)} of the column");
+        }
+
+        if (!column.IsSortable(this))
+        {
+            throw new InvalidOperationException($"{column.PropertyName} column is not sortable");
+        }
+
         if (!IsSortable)
         {
             throw new InvalidOperationException("DataGrid is not sortable");
-        }
-
-        if (column.PropertyName == null)
-        {
-            throw new InvalidOperationException("Please set 'PropertyName' of the Column");
         }
 
         var items = InternalItems;
@@ -506,8 +511,9 @@ public partial class DataGrid
     }
 
     /// <summary>
-    /// Determines if the grid is sortable. Default value is true.
-    /// If you want to disable sorting for specific column please use <c>SortingEnabled</c> property
+    /// Gets or sets if the grid is sortable. Default value is true.
+    /// Sortable columns must implement <see cref="IComparable"/>
+    /// If you want to enable or disable sorting for specific column please use <c>SortingEnabled</c> property
     /// </summary>
     public bool IsSortable
     {
@@ -703,7 +709,7 @@ public partial class DataGrid
         column.HeaderLabel.Style = column.HeaderLabelStyle ??
                                    HeaderLabelStyle ?? (Style)_headerView.Resources["HeaderDefaultStyle"];
 
-        if (IsSortable && column.SortingEnabled)
+        if (IsSortable && column.IsSortable(this) && column.SortingEnabled)
         {
             column.SortingIcon.Style = SortIconStyle ?? (Style)_headerView.Resources["SortIconStyle"];
             column.SortingIconContainer.HeightRequest = HeaderHeight * 0.3;

--- a/Maui.DataGrid/DataGridColumn.cs
+++ b/Maui.DataGrid/DataGridColumn.cs
@@ -8,6 +8,7 @@ namespace Maui.DataGrid;
 /// </summary>
 public class DataGridColumn : BindableObject, IDefinition
 {
+    private bool? _isSortable;
     private ColumnDefinition _columnDefinition;
     private readonly ColumnDefinition _invisibleColumnDefinition = new(0);
 
@@ -235,11 +236,37 @@ public class DataGridColumn : BindableObject, IDefinition
 
     /// <summary>
     /// Defines if the column is sortable. Default is true
+    /// Sortable columns must implement <see cref="IComparable"/>
     /// </summary>
     public bool SortingEnabled
     {
         get => (bool)GetValue(SortingEnabledProperty);
         set => SetValue(SortingEnabledProperty, value);
+    }
+
+    /// <summary>
+    /// Determines via reflection if the column's data type is sortable.
+    /// If you want to disable sorting for specific column please use <c>SortingEnabled</c> property
+    /// </summary>
+    public bool IsSortable(DataGrid dataGrid)
+    {
+        if (_isSortable is not null)
+        {
+            return _isSortable.Value;
+        }
+
+        try
+        {
+            var listItemType = dataGrid.ItemsSource.GetType().GetGenericArguments().Single();
+            var columnDataType = listItemType.GetProperty(PropertyName).PropertyType;
+            _isSortable = typeof(IComparable).IsAssignableFrom(columnDataType);
+        }
+        catch
+        {
+            _isSortable = false;
+        }
+
+        return _isSortable ?? false;
     }
 
     /// <summary>


### PR DESCRIPTION
Can only do sorting via reflection if the type of the column implements IComparable. So this PR uses reflection to determine if this is the case, and caches the result.

Biggest change is that I moved where the header initialization happens, because it needs access to the ItemsSource to generate the header with the current approach of constructing the sorting icons with the gesture recognizers