### PR TITLE
use a ContentView to wrap everything

### DIFF
--- a/Maui.DataGrid/DataGrid.xaml
+++ b/Maui.DataGrid/DataGrid.xaml
@@ -1,48 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<Grid x:Name="self"
+<ContentView x:Name="self"
       xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
       xmlns:local="clr-namespace:Maui.DataGrid;assembly=Maui.DataGrid"
-      x:Class="Maui.DataGrid.DataGrid"
-      Padding="0"
-      RowSpacing="0">
-    <Grid.Resources>
-        <ResourceDictionary>
-            <local:BoolToSelectionModeConverter x:Key="boolToSelectionMode" />
-        </ResourceDictionary>
-    </Grid.Resources>
-    <Grid.RowDefinitions>
-        <RowDefinition Height="Auto" />
-        <RowDefinition Height="*" />
-    </Grid.RowDefinitions>
-    <Grid Grid.Row="0" x:Name="_headerView" RowSpacing="0">
+      x:Class="Maui.DataGrid.DataGrid">
+    <Grid x:Name="_mainGrid">
         <Grid.Resources>
             <ResourceDictionary>
-                <!--Default Header Style-->
-                <Style x:Key="HeaderDefaultStyle" TargetType="Label">
-                    <Setter Property="FontAttributes" Value="Bold" />
-                    <Setter Property="HorizontalOptions" Value="Center" />
-                    <Setter Property="VerticalOptions" Value="Center" />
-                    <Setter Property="TextColor" Value="Black" />
-                    <Setter Property="LineBreakMode" Value="WordWrap" />
-                </Style>
-                <Style x:Key="SortIconStyle" TargetType="Polygon">
-                    <Setter Property="Aspect" Value="Uniform" />
-                    <Setter Property="Fill" Value="Black" />
-                    <Setter Property="Points" Value="50,0 0,80 100,80" />
-                </Style>
+                <local:BoolToSelectionModeConverter x:Key="boolToSelectionMode" />
             </ResourceDictionary>
         </Grid.Resources>
-    </Grid>
-    <RefreshView Grid.Row="1" x:Name="_refreshView" Grid.RowSpan="2" Command="{Binding PullToRefreshCommand, Source={x:Reference self}}" IsRefreshing="{Binding IsRefreshing, Source={x:Reference self}, Mode=TwoWay}">
-        <CollectionView x:Name="_collectionView" SelectedItem="{Binding SelectedItem, Source={x:Reference self}, Mode=TwoWay}"  SelectionMode="{Binding SelectionEnabled, Source={x:Reference self}, Converter={StaticResource boolToSelectionMode}}" >
-            <CollectionView.ItemTemplate>
-                <DataTemplate>
-                    <local:DataGridRow DataGrid="{Reference self}" HeightRequest="{Binding RowHeight, Source={x:Reference self}, Mode=OneTime}" />
-                </DataTemplate>
-            </CollectionView.ItemTemplate>
-        </CollectionView>
-    </RefreshView>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Grid Grid.Row="0" x:Name="_headerView" RowSpacing="0">
+            <Grid.Resources>
+                <ResourceDictionary>
+                    <!--Default Header Style-->
+                    <Style x:Key="HeaderDefaultStyle" TargetType="Label">
+                        <Setter Property="FontAttributes" Value="Bold" />
+                        <Setter Property="HorizontalOptions" Value="Center" />
+                        <Setter Property="VerticalOptions" Value="Center" />
+                        <Setter Property="TextColor" Value="Black" />
+                        <Setter Property="LineBreakMode" Value="WordWrap" />
+                    </Style>
+                    <Style x:Key="SortIconStyle" TargetType="Polygon">
+                        <Setter Property="Aspect" Value="Uniform" />
+                        <Setter Property="Fill" Value="Black" />
+                        <Setter Property="Points" Value="50,0 0,80 100,80" />
+                    </Style>
+                </ResourceDictionary>
+            </Grid.Resources>
+        </Grid>
+        <RefreshView Grid.Row="1" x:Name="_refreshView" Grid.RowSpan="2" Command="{Binding PullToRefreshCommand, Source={x:Reference self}}" IsRefreshing="{Binding IsRefreshing, Source={x:Reference self}, Mode=TwoWay}">
+            <CollectionView x:Name="_collectionView" SelectedItem="{Binding SelectedItem, Source={x:Reference self}, Mode=TwoWay}"  SelectionMode="{Binding SelectionEnabled, Source={x:Reference self}, Converter={StaticResource boolToSelectionMode}}" >
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <local:DataGridRow DataGrid="{Reference self}" HeightRequest="{Binding RowHeight, Source={x:Reference self}, Mode=OneTime}" />
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </RefreshView>
 
-</Grid>
+    </Grid>
+</ContentView>


### PR DESCRIPTION
The Grid control provides a lot of bindable properties like ColumnDefinitions, RowDefinitions, ColumnSpacing, RowSpacing which could mislead a user, since the API doesn't respect those in a way that would make sense for a user.