### PR TITLE
EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,450 @@
+# Version: 4.1.1 (Using https://semver.org/)
+# Updated: 2022-05-23
+# See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
+# See https://github.com/RehanSaeed/EditorConfig for updates to this file.
+# See http://EditorConfig.org for more information about .editorconfig files.
+
+##########################################
+# Common Settings
+##########################################
+
+# This file is the top-most EditorConfig file
+root = true
+
+# All Files
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+##########################################
+# File Extension Settings
+##########################################
+
+# Visual Studio Solution Files
+[*.sln]
+indent_style = tab
+
+# Visual Studio XML Project Files
+[*.{csproj,vbproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# XML Configuration Files
+[*.{xml,config,props,targets,nuspec,resx,ruleset,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON Files
+[*.{json,json5,webmanifest}]
+indent_size = 2
+
+# YAML Files
+[*.{yml,yaml}]
+indent_size = 2
+
+# Markdown Files
+[*.{md,mdx}]
+trim_trailing_whitespace = false
+
+# Web Files
+[*.{htm,html,js,jsm,ts,tsx,cjs,cts,ctsx,mjs,mts,mtsx,css,sass,scss,less,pcss,svg,vue}]
+indent_size = 2
+
+# Batch Files
+[*.{cmd,bat}]
+end_of_line = crlf
+
+# Bash Files
+[*.sh]
+end_of_line = lf
+
+# Makefiles
+[Makefile]
+indent_style = tab
+
+##########################################
+# Default .NET Code Style Severities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/configuration-options#scope
+##########################################
+
+[*.{cs,csx,cake,vb,vbx}]
+# Default Severity for all .NET Code Style rules below
+dotnet_analyzer_diagnostic.severity = warning
+
+##########################################
+# Language Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules
+##########################################
+
+# .NET Style Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#net-style-rules
+[*.{cs,csx,cake,vb,vbx}]
+# "this." and "Me." qualifiers
+dotnet_style_qualification_for_field = true:warning
+dotnet_style_qualification_for_property = true:warning
+dotnet_style_qualification_for_method = true:warning
+dotnet_style_qualification_for_event = true:warning
+# Language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = always:warning
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:warning
+dotnet_style_readonly_field = true:warning
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
+# Expression-level preferences
+dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
+dotnet_style_explicit_tuple_names = true:warning
+dotnet_style_prefer_inferred_tuple_names = true:warning
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
+dotnet_style_prefer_auto_properties = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment = false:suggestion
+dotnet_diagnostic.IDE0045.severity = suggestion
+dotnet_style_prefer_conditional_expression_over_return = false:suggestion
+dotnet_diagnostic.IDE0046.severity = suggestion
+dotnet_style_prefer_compound_assignment = true:warning
+dotnet_style_prefer_simplified_interpolation = true:warning
+dotnet_style_prefer_simplified_boolean_expressions = true:warning
+# Null-checking preferences
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+# File header preferences
+# file_header_template = <copyright file="{fileName}" company="PROJECT-AUTHOR">\n© PROJECT-AUTHOR\n</copyright>
+# If you use StyleCop, you'll need to disable SA1636: File header copyright text should match.
+# dotnet_diagnostic.SA1636.severity = none
+# Undocumented
+dotnet_style_operator_placement_when_wrapping = end_of_line:warning
+csharp_style_prefer_null_check_over_type_check = true:warning
+
+# C# Style Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules
+[*.{cs,csx,cake}]
+# 'var' preferences
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:warning
+csharp_style_expression_bodied_constructors = true:none
+csharp_style_expression_bodied_operators = true:warning
+csharp_style_expression_bodied_properties = true:warning
+csharp_style_expression_bodied_indexers = true:warning
+csharp_style_expression_bodied_accessors = true:warning
+csharp_style_expression_bodied_lambdas = true:warning
+csharp_style_expression_bodied_local_functions = true:warning
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_prefer_switch_expression = true:warning
+csharp_style_prefer_pattern_matching = true:warning
+csharp_style_prefer_not_pattern = true:warning
+# Expression-level preferences
+csharp_style_inlined_variable_declaration = true:warning
+csharp_prefer_simple_default_expression = true:warning
+csharp_style_pattern_local_over_anonymous_function = true:warning
+csharp_style_deconstructed_variable_declaration = true:warning
+csharp_style_prefer_index_operator = true:warning
+csharp_style_prefer_range_operator = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+# "Null" checking preferences
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+# Code block preferences
+csharp_prefer_braces = true:warning
+csharp_prefer_simple_using_statement = true:suggestion
+dotnet_diagnostic.IDE0063.severity = suggestion
+# 'using' directive preferences
+csharp_using_directive_placement = inside_namespace:warning
+# Modifier preferences
+csharp_prefer_static_local_function = true:warning
+
+##########################################
+# Unnecessary Code Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/unnecessary-code-rules
+##########################################
+
+# .NET Unnecessary code rules
+[*.{cs,csx,cake,vb,vbx}]
+dotnet_code_quality_unused_parameters = all:warning
+dotnet_remove_unnecessary_suppression_exclusions = none:warning
+
+# C# Unnecessary code rules
+[*.{cs,csx,cake}]
+csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion
+dotnet_diagnostic.IDE0058.severity = suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+dotnet_diagnostic.IDE0059.severity = suggestion
+
+##########################################
+# Formatting Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules
+##########################################
+
+# .NET formatting rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#net-formatting-rules
+[*.{cs,csx,cake,vb,vbx}]
+# Organize using directives
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+# Dotnet namespace options
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_diagnostic.IDE0130.severity = suggestion
+
+# C# formatting rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#c-formatting-rules
+[*.{cs,csx,cake}]
+# Newline options
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#new-line-options
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation options
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#indentation-options
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = no_change
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = false
+# Spacing options
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#spacing-options
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_after_comma = true
+csharp_space_before_comma = false
+csharp_space_after_dot = false
+csharp_space_before_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
+# Wrap options
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#wrap-options
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+# Namespace options
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#namespace-options
+csharp_style_namespace_declarations = file_scoped:warning
+
+##########################################
+# .NET Naming Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/naming-rules
+##########################################
+
+[*.{cs,csx,cake,vb,vbx}]
+
+##########################################
+# Styles
+##########################################
+
+# camel_case_style - Define the camelCase style
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+# pascal_case_style - Define the PascalCase style
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+# first_upper_style - The first character must start with an upper-case character
+dotnet_naming_style.first_upper_style.capitalization = first_word_upper
+# prefix_interface_with_i_style - Interfaces must be PascalCase and the first character of an interface must be an 'I'
+dotnet_naming_style.prefix_interface_with_i_style.capitalization = pascal_case
+dotnet_naming_style.prefix_interface_with_i_style.required_prefix = I
+# prefix_type_parameters_with_t_style - Generic Type Parameters must be PascalCase and the first character must be a 'T'
+dotnet_naming_style.prefix_type_parameters_with_t_style.capitalization = pascal_case
+dotnet_naming_style.prefix_type_parameters_with_t_style.required_prefix = T
+# disallowed_style - Anything that has this style applied is marked as disallowed
+dotnet_naming_style.disallowed_style.capitalization  = pascal_case
+dotnet_naming_style.disallowed_style.required_prefix = ____RULE_VIOLATION____
+dotnet_naming_style.disallowed_style.required_suffix = ____RULE_VIOLATION____
+# internal_error_style - This style should never occur... if it does, it indicates a bug in file or in the parser using the file
+dotnet_naming_style.internal_error_style.capitalization  = pascal_case
+dotnet_naming_style.internal_error_style.required_prefix = ____INTERNAL_ERROR____
+dotnet_naming_style.internal_error_style.required_suffix = ____INTERNAL_ERROR____
+
+##########################################
+# .NET Design Guideline Field Naming Rules
+# Naming rules for fields follow the .NET Framework design guidelines
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/index
+##########################################
+
+# All public/protected/protected_internal constant fields must be PascalCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.public_protected_constant_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.public_protected_constant_fields_group.required_modifiers         = const
+dotnet_naming_symbols.public_protected_constant_fields_group.applicable_kinds           = field
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.symbols    = public_protected_constant_fields_group
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.severity   = warning
+
+# All public/protected/protected_internal static readonly fields must be PascalCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.required_modifiers         = static, readonly
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_kinds           = field
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.symbols    = public_protected_static_readonly_fields_group
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.severity   = warning
+
+# No other public/protected/protected_internal fields are allowed
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.other_public_protected_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.other_public_protected_fields_group.applicable_kinds           = field
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.symbols             = other_public_protected_fields_group
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.style               = disallowed_style
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.severity            = error
+
+##########################################
+# StyleCop Field Naming Rules
+# Naming rules for fields follow the StyleCop analyzers
+# This does not override any rules using disallowed_style above
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers
+##########################################
+
+# All constant fields must be PascalCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+dotnet_naming_symbols.stylecop_constant_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
+dotnet_naming_symbols.stylecop_constant_fields_group.required_modifiers         = const
+dotnet_naming_symbols.stylecop_constant_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.symbols    = stylecop_constant_fields_group
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.severity   = warning
+
+# All static readonly fields must be PascalCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.required_modifiers         = static, readonly
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.symbols    = stylecop_static_readonly_fields_group
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.severity   = warning
+
+# No non-private instance fields are allowed
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected
+dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.symbols               = stylecop_fields_must_be_private_group
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.style                 = disallowed_style
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.severity              = error
+
+# Private fields must be camelCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+dotnet_naming_symbols.stylecop_private_fields_group.applicable_accessibilities = private
+dotnet_naming_symbols.stylecop_private_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.symbols     = stylecop_private_fields_group
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.style       = camel_case_style
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.severity    = warning
+
+# Local variables must be camelCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+dotnet_naming_symbols.stylecop_local_fields_group.applicable_accessibilities = local
+dotnet_naming_symbols.stylecop_local_fields_group.applicable_kinds           = local
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.symbols     = stylecop_local_fields_group
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.style       = camel_case_style
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.severity    = silent
+
+# This rule should never fire.  However, it's included for at least two purposes:
+# First, it helps to understand, reason about, and root-case certain types of issues, such as bugs in .editorconfig parsers.
+# Second, it helps to raise immediate awareness if a new field type is added (as occurred recently in C#).
+dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_accessibilities = *
+dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_kinds           = field
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.symbols  = sanity_check_uncovered_field_case_group
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.style    = internal_error_style
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.severity = error
+
+
+##########################################
+# Other Naming Rules
+##########################################
+
+# All of the following must be PascalCase:
+# - Namespaces
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-namespaces
+#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# - Classes and Enumerations
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# - Delegates
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces#names-of-common-types
+# - Constructors, Properties, Events, Methods
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-type-members
+dotnet_naming_symbols.element_group.applicable_kinds = namespace, class, enum, struct, delegate, event, method, property
+dotnet_naming_rule.element_rule.symbols              = element_group
+dotnet_naming_rule.element_rule.style                = pascal_case_style
+dotnet_naming_rule.element_rule.severity             = warning
+
+# Interfaces use PascalCase and are prefixed with uppercase 'I'
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+dotnet_naming_symbols.interface_group.applicable_kinds = interface
+dotnet_naming_rule.interface_rule.symbols              = interface_group
+dotnet_naming_rule.interface_rule.style                = prefix_interface_with_i_style
+dotnet_naming_rule.interface_rule.severity             = warning
+
+# Generics Type Parameters use PascalCase and are prefixed with uppercase 'T'
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+dotnet_naming_symbols.type_parameter_group.applicable_kinds = type_parameter
+dotnet_naming_rule.type_parameter_rule.symbols              = type_parameter_group
+dotnet_naming_rule.type_parameter_rule.style                = prefix_type_parameters_with_t_style
+dotnet_naming_rule.type_parameter_rule.severity             = warning
+
+# Function parameters use camelCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/naming-parameters
+dotnet_naming_symbols.parameters_group.applicable_kinds = parameter
+dotnet_naming_rule.parameters_rule.symbols              = parameters_group
+dotnet_naming_rule.parameters_rule.style                = camel_case_style
+dotnet_naming_rule.parameters_rule.severity             = warning
+
+##########################################
+# License
+##########################################
+# The following applies as to the .editorconfig file ONLY, and is
+# included below for reference, per the requirements of the license
+# corresponding to this .editorconfig file.
+# See: https://github.com/RehanSaeed/EditorConfig
+#
+# MIT License
+#
+# Copyright (c) 2017-2019 Muhammad Rehan Saeed
+# Copyright (c) 2019 Henry Gabryjelski
+#
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute,
+# sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject
+# to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+##########################################

--- a/Maui.DataGrid.Sample/App.xaml.cs
+++ b/Maui.DataGrid.Sample/App.xaml.cs
@@ -3,10 +3,10 @@
 [XamlCompilation(XamlCompilationOptions.Compile)]
 public partial class App
 {
-	public App()
-	{
-		InitializeComponent();
+    public App()
+    {
+        this.InitializeComponent();
 
-		MainPage = new AppShell();
-	}
+        this.MainPage = new AppShell();
+    }
 }

--- a/Maui.DataGrid.Sample/AppShell.xaml.cs
+++ b/Maui.DataGrid.Sample/AppShell.xaml.cs
@@ -3,8 +3,8 @@
 [XamlCompilation(XamlCompilationOptions.Compile)]
 public partial class AppShell
 {
-	public AppShell()
-	{
-		InitializeComponent();
-	}
+    public AppShell()
+    {
+        this.InitializeComponent();
+    }
 }

--- a/Maui.DataGrid.Sample/MainPage.xaml.cs
+++ b/Maui.DataGrid.Sample/MainPage.xaml.cs
@@ -1,16 +1,16 @@
-﻿using System.Globalization;
+namespace Maui.DataGrid.Sample;
+
+using System.Globalization;
 using Maui.DataGrid.Sample.Models;
 using Maui.DataGrid.Sample.ViewModels;
-
-namespace Maui.DataGrid.Sample;
 
 [XamlCompilation(XamlCompilationOptions.Compile)]
 public partial class MainPage
 {
     public MainPage()
     {
-        InitializeComponent();
-        BindingContext = new MainViewModel();
+        this.InitializeComponent();
+        this.BindingContext = new MainViewModel();
     }
 }
 
@@ -27,8 +27,5 @@ internal class StreakToColorConverter : IValueConverter
         return Colors.Transparent;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
 }

--- a/Maui.DataGrid.Sample/MauiProgram.cs
+++ b/Maui.DataGrid.Sample/MauiProgram.cs
@@ -2,17 +2,17 @@
 
 public static class MauiProgram
 {
-	public static MauiApp CreateMauiApp()
-	{
-		var builder = MauiApp.CreateBuilder();
-		builder
-			.UseMauiApp<App>()
-			.ConfigureFonts(fonts =>
-			{
-				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
-				fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
-			});
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiApp<App>()
+            .ConfigureFonts(fonts =>
+            {
+                fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+                fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+            });
 
-		return builder.Build();
-	}
+        return builder.Build();
+    }
 }

--- a/Maui.DataGrid.Sample/Models/Team.cs
+++ b/Maui.DataGrid.Sample/Models/Team.cs
@@ -22,7 +22,7 @@ public class Streak : IComparable
 
     public int CompareTo(object other)
     {
-        var score = Result == Result.Win ? NumStreak : -NumStreak;
+        var score = this.Result == Result.Win ? this.NumStreak : -this.NumStreak;
         if (other is Streak s)
         {
             var otherScore = s.Result == Result.Win ? s.NumStreak : -s.NumStreak;
@@ -32,10 +32,7 @@ public class Streak : IComparable
         return score;
     }
 
-    public override string ToString()
-    {
-        return $"{Enum.GetName(typeof(Result), Result)} {NumStreak}";
-    }
+    public override string ToString() => $"{Enum.GetName(typeof(Result), this.Result)} {this.NumStreak}";
 }
 
 public enum Result

--- a/Maui.DataGrid.Sample/Platforms/Android/MainActivity.cs
+++ b/Maui.DataGrid.Sample/Platforms/Android/MainActivity.cs
@@ -1,8 +1,8 @@
-﻿using Android.App;
-using Android.Content.PM;
-using Android.OS;
-
 namespace Maui.DataGrid.Sample.Platforms.Android;
+
+using global::Android.App;
+using global::Android.Content.PM;
+using global::Android.OS;
 
 [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity

--- a/Maui.DataGrid.Sample/Platforms/Android/MainApplication.cs
+++ b/Maui.DataGrid.Sample/Platforms/Android/MainApplication.cs
@@ -1,15 +1,15 @@
-﻿using Android.App;
-using Android.Runtime;
-
 namespace Maui.DataGrid.Sample.Platforms.Android;
+
+using global::Android.App;
+using global::Android.Runtime;
 
 [Application]
 public class MainApplication : MauiApplication
 {
-  public MainApplication(IntPtr handle, JniHandleOwnership ownership)
-    : base(handle, ownership)
-  {
-  }
+    public MainApplication(IntPtr handle, JniHandleOwnership ownership)
+      : base(handle, ownership)
+    {
+    }
 
-  protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
 }

--- a/Maui.DataGrid.Sample/Platforms/MacCatalyst/AppDelegate.cs
+++ b/Maui.DataGrid.Sample/Platforms/MacCatalyst/AppDelegate.cs
@@ -1,9 +1,9 @@
-﻿using Foundation;
-
 namespace Maui.DataGrid.Sample.Platforms.MacCatalyst;
+
+using Foundation;
 
 [Register("AppDelegate")]
 public class AppDelegate : MauiUIApplicationDelegate
 {
-  protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
 }

--- a/Maui.DataGrid.Sample/Platforms/MacCatalyst/Program.cs
+++ b/Maui.DataGrid.Sample/Platforms/MacCatalyst/Program.cs
@@ -1,15 +1,12 @@
-﻿using ObjCRuntime;
-using UIKit;
-
 namespace Maui.DataGrid.Sample.Platforms.MacCatalyst;
+
+using UIKit;
 
 public class Program
 {
-  // This is the main entry point of the application.
-  static void Main(string[] args)
-  {
-    // if you want to use a different Application Delegate class from "AppDelegate"
-    // you can specify it here.
-    UIApplication.Main(args, null, typeof(AppDelegate));
-  }
+    // This is the main entry point of the application.
+    private static void Main(string[] args) =>
+      // if you want to use a different Application Delegate class from "AppDelegate"
+      // you can specify it here.
+      UIApplication.Main(args, null, typeof(AppDelegate));
 }

--- a/Maui.DataGrid.Sample/Platforms/Tizen/Main.cs
+++ b/Maui.DataGrid.Sample/Platforms/Tizen/Main.cs
@@ -1,8 +1,8 @@
+namespace Maui.DataGrid.Sample;
+
 using System;
 using Microsoft.Maui;
 using Microsoft.Maui.Hosting;
-
-namespace Maui.DataGrid.Sample;
 
 class Program : MauiApplication
 {

--- a/Maui.DataGrid.Sample/Platforms/Windows/App.xaml.cs
+++ b/Maui.DataGrid.Sample/Platforms/Windows/App.xaml.cs
@@ -1,24 +1,23 @@
-﻿using Microsoft.UI.Xaml;
-
-// To learn more about WinUI, the WinUI project structure,
+﻿// To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Maui.DataGrid.Sample.WinUI;
+using Microsoft.UI.Xaml;
 
 /// <summary>
 /// Provides application-specific behavior to supplement the default Application class.
 /// </summary>
 public partial class App : MauiWinUIApplication
 {
-	/// <summary>
-	/// Initializes the singleton application object.  This is the first line of authored code
-	/// executed, and as such is the logical equivalent of main() or WinMain().
-	/// </summary>
-	public App()
-	{
-		this.InitializeComponent();
-	}
+    /// <summary>
+    /// Initializes the singleton application object.  This is the first line of authored code
+    /// executed, and as such is the logical equivalent of main() or WinMain().
+    /// </summary>
+    public App()
+    {
+        this.InitializeComponent();
+    }
 
-	protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
 }
 

--- a/Maui.DataGrid.Sample/Platforms/iOS/AppDelegate.cs
+++ b/Maui.DataGrid.Sample/Platforms/iOS/AppDelegate.cs
@@ -1,9 +1,9 @@
-﻿using Foundation;
-
 namespace Maui.DataGrid.Sample.Platforms.iOS;
+
+using Foundation;
 
 [Register("AppDelegate")]
 public class AppDelegate : MauiUIApplicationDelegate
 {
-  protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
 }

--- a/Maui.DataGrid.Sample/Platforms/iOS/Program.cs
+++ b/Maui.DataGrid.Sample/Platforms/iOS/Program.cs
@@ -1,15 +1,12 @@
-﻿using ObjCRuntime;
-using UIKit;
-
 namespace Maui.DataGrid.Sample.Platforms.iOS;
+
+using UIKit;
 
 public class Program
 {
-  // This is the main entry point of the application.
-  static void Main(string[] args)
-  {
-    // if you want to use a different Application Delegate class from "AppDelegate"
-    // you can specify it here.
-    UIApplication.Main(args, null, typeof(AppDelegate));
-  }
+    // This is the main entry point of the application.
+    private static void Main(string[] args) =>
+      // if you want to use a different Application Delegate class from "AppDelegate"
+      // you can specify it here.
+      UIApplication.Main(args, null, typeof(AppDelegate));
 }

--- a/Maui.DataGrid.Sample/Utils/DummyDataProvider.cs
+++ b/Maui.DataGrid.Sample/Utils/DummyDataProvider.cs
@@ -1,8 +1,8 @@
-﻿using System.Reflection;
+namespace Maui.DataGrid.Sample.Utils;
+
+using System.Reflection;
 using Maui.DataGrid.Sample.Models;
 using Newtonsoft.Json;
-
-namespace Maui.DataGrid.Sample.Utils;
 
 internal static class DummyDataProvider
 {

--- a/Maui.DataGrid.Sample/ViewModels/MainViewModel.cs
+++ b/Maui.DataGrid.Sample/ViewModels/MainViewModel.cs
@@ -1,83 +1,83 @@
-﻿using System.ComponentModel;
+namespace Maui.DataGrid.Sample.ViewModels;
+
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows.Input;
 using Maui.DataGrid.Sample.Models;
 using Maui.DataGrid.Sample.Utils;
 
-namespace Maui.DataGrid.Sample.ViewModels;
-
 public class MainViewModel : INotifyPropertyChanged
 {
-    private List<Team> _teams;
-    private Team _selectedItem;
-    private bool _isRefreshing;
-    private bool _teamColumnVisible = true;
-    private bool _winColumnVisible = true;
-    private bool _headerBordersVisible = true;
+    private List<Team> teams;
+    private Team selectedItem;
+    private bool isRefreshing;
+    private bool teamColumnVisible = true;
+    private bool winColumnVisible = true;
+    private bool headerBordersVisible = true;
 
     public MainViewModel()
     {
-        Teams = DummyDataProvider.GetTeams();
-        RefreshCommand = new Command(CmdRefresh);
+        this.Teams = DummyDataProvider.GetTeams();
+        this.RefreshCommand = new Command(this.CmdRefresh);
     }
 
     public List<Team> Teams
     {
-        get => _teams;
+        get => this.teams;
         set
         {
-            _teams = value;
-            OnPropertyChanged(nameof(Teams));
+            this.teams = value;
+            this.OnPropertyChanged(nameof(this.Teams));
         }
     }
 
     public bool HeaderBordersVisible
     {
-        get => _headerBordersVisible;
+        get => this.headerBordersVisible;
         set
         {
-            _headerBordersVisible = value;
-            OnPropertyChanged(nameof(HeaderBordersVisible));
+            this.headerBordersVisible = value;
+            this.OnPropertyChanged(nameof(this.HeaderBordersVisible));
         }
     }
 
     public bool TeamColumnVisible
     {
-        get => _teamColumnVisible;
+        get => this.teamColumnVisible;
         set
         {
-            _teamColumnVisible = value;
-            OnPropertyChanged(nameof(TeamColumnVisible));
+            this.teamColumnVisible = value;
+            this.OnPropertyChanged(nameof(this.TeamColumnVisible));
         }
     }
 
     public bool WinColumnVisible
     {
-        get => _winColumnVisible;
+        get => this.winColumnVisible;
         set
         {
-            _winColumnVisible = value;
-            OnPropertyChanged(nameof(WinColumnVisible));
+            this.winColumnVisible = value;
+            this.OnPropertyChanged(nameof(this.WinColumnVisible));
         }
     }
 
     public Team SelectedTeam
     {
-        get => _selectedItem;
+        get => this.selectedItem;
         set
         {
-            _selectedItem = value;
+            this.selectedItem = value;
             Debug.WriteLine("Team Selected : " + value?.Name);
         }
     }
 
     public bool IsRefreshing
     {
-        get => _isRefreshing;
+        get => this.isRefreshing;
         set
         {
-            _isRefreshing = value;
-            OnPropertyChanged(nameof(IsRefreshing));
+            this.isRefreshing = value;
+            this.OnPropertyChanged(nameof(this.IsRefreshing));
         }
     }
 
@@ -85,20 +85,17 @@ public class MainViewModel : INotifyPropertyChanged
 
     private async void CmdRefresh()
     {
-        IsRefreshing = true;
+        this.IsRefreshing = true;
         // wait 3 secs for demo
         await Task.Delay(3000);
-        IsRefreshing = false;
+        this.IsRefreshing = false;
     }
 
-  #region INotifyPropertyChanged implementation
+    #region INotifyPropertyChanged implementation
 
-  public event PropertyChangedEventHandler PropertyChanged;
+    public event PropertyChangedEventHandler PropertyChanged;
 
-    private void OnPropertyChanged(string property)
-    {
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(property));
-    }
+    private void OnPropertyChanged(string property) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(property));
 
-    #endregion
+    #endregion INotifyPropertyChanged implementation
 }

--- a/Maui.DataGrid/BoolToSelectionModeConverter.cs
+++ b/Maui.DataGrid/BoolToSelectionModeConverter.cs
@@ -1,17 +1,11 @@
-﻿using System.Globalization;
+﻿namespace Maui.DataGrid;
 
-namespace Maui.DataGrid;
+using System.Globalization;
 
 internal class BoolToSelectionModeConverter : IValueConverter
 {
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        return value is true ?
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => value is true ?
             SelectionMode.Single : SelectionMode.None;
-    }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
 }

--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -1,3 +1,4 @@
+namespace Maui.DataGrid;
 using System.Collections;
 using System.Collections.Specialized;
 using System.Windows.Input;
@@ -5,53 +6,51 @@ using Maui.DataGrid.Utils;
 using Microsoft.Maui.Controls.Shapes;
 using Font = Microsoft.Maui.Font;
 
-namespace Maui.DataGrid;
-
 /// <summary>
 /// DataGrid component for Maui
 /// </summary>
 [XamlCompilation(XamlCompilationOptions.Compile)]
 public partial class DataGrid
 {
-    private readonly Dictionary<int, SortingOrder> _sortingOrders;
+    private readonly Dictionary<int, SortingOrder> sortingOrders;
 
-    private readonly WeakEventManager _itemSelectedEventManager = new();
+    private readonly WeakEventManager itemSelectedEventManager = new();
 
     public event EventHandler<SelectionChangedEventArgs> ItemSelected
     {
-        add => _itemSelectedEventManager.AddEventHandler(value);
-        remove => _itemSelectedEventManager.RemoveEventHandler(value);
+        add => this.itemSelectedEventManager.AddEventHandler(value);
+        remove => this.itemSelectedEventManager.RemoveEventHandler(value);
     }
 
-    private readonly WeakEventManager _refreshingEventManager = new();
+    private readonly WeakEventManager refreshingEventManager = new();
 
     public event EventHandler Refreshing
     {
-        add => _refreshingEventManager.AddEventHandler(value);
-        remove => _refreshingEventManager.RemoveEventHandler(value);
+        add => this.refreshingEventManager.AddEventHandler(value);
+        remove => this.refreshingEventManager.RemoveEventHandler(value);
     }
 
     #region ctor
 
     public DataGrid()
     {
-        InitializeComponent();
+        this.InitializeComponent();
 
-        _sortingOrders = new();
+        this.sortingOrders = new();
     }
 
-    #endregion
+    #endregion ctor
 
     #region Sorting methods
 
     internal void SortItems(SortData sortData)
     {
-        if (InternalItems == null || sortData.Index >= Columns.Count || !Columns[sortData.Index].SortingEnabled)
+        if (this.InternalItems == null || sortData.Index >= this.Columns.Count || !this.Columns[sortData.Index].SortingEnabled)
         {
             return;
         }
 
-        var column = Columns[sortData.Index];
+        var column = this.Columns[sortData.Index];
         var order = sortData.Order;
 
         if (column.PropertyName == null)
@@ -64,47 +63,47 @@ public partial class DataGrid
             throw new InvalidOperationException($"{column.PropertyName} column is not sortable");
         }
 
-        if (!IsSortable)
+        if (!this.IsSortable)
         {
             throw new InvalidOperationException("DataGrid is not sortable");
         }
 
-        var items = InternalItems;
+        var items = this.InternalItems;
 
         switch (order)
         {
             case SortingOrder.Ascendant:
                 items = items.OrderBy(x => ReflectionUtils.GetValueByPath(x, column.PropertyName)).ToList();
-                column.SortingIcon.RotateTo(0);
+                _ = column.SortingIcon.RotateTo(0);
                 break;
             case SortingOrder.Descendant:
                 items = items.OrderByDescending(x => ReflectionUtils.GetValueByPath(x, column.PropertyName)).ToList();
-                column.SortingIcon.RotateTo(180);
+                _ = column.SortingIcon.RotateTo(180);
                 break;
         }
 
-        for (var i = 0; i < Columns.Count; i++)
+        for (var i = 0; i < this.Columns.Count; i++)
         {
             if (i != sortData.Index)
             {
-                _sortingOrders[i] = SortingOrder.None;
-                Columns[i].SortingIconContainer.IsVisible = false;
+                this.sortingOrders[i] = SortingOrder.None;
+                this.Columns[i].SortingIconContainer.IsVisible = false;
             }
             else
             {
-                Columns[i].SortingIconContainer.IsVisible = true;
+                this.Columns[i].SortingIconContainer.IsVisible = true;
             }
         }
 
-        _internalItems = items;
+        this.internalItems = items;
 
-        _sortingOrders[sortData.Index] = order;
-        SortedColumnIndex = sortData;
+        this.sortingOrders[sortData.Index] = order;
+        this.SortedColumnIndex = sortData;
 
-        _collectionView.ItemsSource = _internalItems;
+        this._collectionView.ItemsSource = this.internalItems;
     }
 
-    #endregion
+    #endregion Sorting methods
 
     #region Methods
 
@@ -114,12 +113,9 @@ public partial class DataGrid
     /// <param name="item">Item to scroll</param>
     /// <param name="position">Position of the row in screen</param>
     /// <param name="animated">animated</param>
-    public void ScrollTo(object item, ScrollToPosition position, bool animated = true)
-    {
-        _collectionView.ScrollTo(item, position: position, animate: animated);
-    }
+    public void ScrollTo(object item, ScrollToPosition position, bool animated = true) => this._collectionView.ScrollTo(item, position: position, animate: animated);
 
-    #endregion
+    #endregion Methods
 
     #region Bindable properties
 
@@ -229,10 +225,10 @@ public partial class DataGrid
     {
         if (sender is IEnumerable items)
         {
-            InternalItems = new List<object>(items.Cast<object>());
-            if (SelectedItem != null && !InternalItems.Contains(SelectedItem))
+            this.InternalItems = new List<object>(items.Cast<object>());
+            if (this.SelectedItem != null && !this.InternalItems.Contains(this.SelectedItem))
             {
-                SelectedItem = null;
+                this.SelectedItem = null;
             }
         }
     }
@@ -303,7 +299,7 @@ public partial class DataGrid
                 var self = (DataGrid)b;
                 if (n is bool refreshingEnabled)
                 {
-                    self.PullToRefreshCommand?.CanExecute(() => refreshingEnabled);
+                    _ = self.PullToRefreshCommand?.CanExecute(() => refreshingEnabled);
                 }
             });
 
@@ -319,7 +315,7 @@ public partial class DataGrid
                 else
                 {
                     self._refreshView.Command = n as ICommand;
-                    self._refreshView.Command?.CanExecute(self.RefreshingEnabled);
+                    _ = self._refreshView.Command?.CanExecute(self.RefreshingEnabled);
                 }
             });
 
@@ -391,7 +387,7 @@ public partial class DataGrid
                 }
             });
 
-    #endregion
+    #endregion Bindable properties
 
     #region Properties
 
@@ -400,8 +396,8 @@ public partial class DataGrid
     /// </summary>
     public Color ActiveRowColor
     {
-        get => (Color)GetValue(ActiveRowColorProperty);
-        set => SetValue(ActiveRowColorProperty, value);
+        get => (Color)this.GetValue(ActiveRowColorProperty);
+        set => this.SetValue(ActiveRowColorProperty, value);
     }
 
     /// <summary>
@@ -410,8 +406,8 @@ public partial class DataGrid
     /// </summary>
     public Color HeaderBackground
     {
-        get => (Color)GetValue(HeaderBackgroundProperty);
-        set => SetValue(HeaderBackgroundProperty, value);
+        get => (Color)this.GetValue(HeaderBackgroundProperty);
+        set => this.SetValue(HeaderBackgroundProperty, value);
     }
 
     /// <summary>
@@ -420,8 +416,8 @@ public partial class DataGrid
     /// </summary>
     public Color BorderColor
     {
-        get => (Color)GetValue(BorderColorProperty);
-        set => SetValue(BorderColorProperty, value);
+        get => (Color)this.GetValue(BorderColorProperty);
+        set => this.SetValue(BorderColorProperty, value);
     }
 
     /// <summary>
@@ -429,8 +425,8 @@ public partial class DataGrid
     /// </summary>
     public IColorProvider RowsBackgroundColorPalette
     {
-        get => (IColorProvider)GetValue(RowsBackgroundColorPaletteProperty);
-        set => SetValue(RowsBackgroundColorPaletteProperty, value);
+        get => (IColorProvider)this.GetValue(RowsBackgroundColorPaletteProperty);
+        set => this.SetValue(RowsBackgroundColorPaletteProperty, value);
     }
 
     /// <summary>
@@ -438,8 +434,8 @@ public partial class DataGrid
     /// </summary>
     public IColorProvider RowsTextColorPalette
     {
-        get => (IColorProvider)GetValue(RowsTextColorPaletteProperty);
-        set => SetValue(RowsTextColorPaletteProperty, value);
+        get => (IColorProvider)this.GetValue(RowsTextColorPaletteProperty);
+        set => this.SetValue(RowsTextColorPaletteProperty, value);
     }
 
     /// <summary>
@@ -447,26 +443,26 @@ public partial class DataGrid
     /// </summary>
     public IEnumerable ItemsSource
     {
-        get => (IEnumerable)GetValue(ItemsSourceProperty);
-        set => SetValue(ItemsSourceProperty, value);
+        get => (IEnumerable)this.GetValue(ItemsSourceProperty);
+        set => this.SetValue(ItemsSourceProperty, value);
     }
 
-    private IList<object>? _internalItems;
+    private IList<object>? internalItems;
 
     internal IList<object>? InternalItems
     {
-        get => _internalItems;
+        get => this.internalItems;
         set
         {
-            _internalItems = value;
+            this.internalItems = value;
 
-            if (IsSortable && SortedColumnIndex != null)
+            if (this.IsSortable && this.SortedColumnIndex != null)
             {
-                SortItems(SortedColumnIndex);
+                this.SortItems(this.SortedColumnIndex);
             }
             else
             {
-                _collectionView.ItemsSource = _internalItems;
+                this._collectionView.ItemsSource = this.internalItems;
             }
         }
     }
@@ -476,8 +472,8 @@ public partial class DataGrid
     /// </summary>
     public ColumnCollection Columns
     {
-        get => (ColumnCollection)GetValue(ColumnsProperty);
-        set => SetValue(ColumnsProperty, value);
+        get => (ColumnCollection)this.GetValue(ColumnsProperty);
+        set => this.SetValue(ColumnsProperty, value);
     }
 
     /// <summary>
@@ -486,8 +482,8 @@ public partial class DataGrid
     /// </summary>
     public double FontSize
     {
-        get => (double)GetValue(FontSizeProperty);
-        set => SetValue(FontSizeProperty, value);
+        get => (double)this.GetValue(FontSizeProperty);
+        set => this.SetValue(FontSizeProperty, value);
     }
 
     /// <summary>
@@ -496,8 +492,8 @@ public partial class DataGrid
     /// </summary>
     public string FontFamily
     {
-        get => (string)GetValue(FontFamilyProperty);
-        set => SetValue(FontFamilyProperty, value);
+        get => (string)this.GetValue(FontFamilyProperty);
+        set => this.SetValue(FontFamilyProperty, value);
     }
 
     /// <summary>
@@ -505,8 +501,8 @@ public partial class DataGrid
     /// </summary>
     public int RowHeight
     {
-        get => (int)GetValue(RowHeightProperty);
-        set => SetValue(RowHeightProperty, value);
+        get => (int)this.GetValue(RowHeightProperty);
+        set => this.SetValue(RowHeightProperty, value);
     }
 
     /// <summary>
@@ -514,8 +510,8 @@ public partial class DataGrid
     /// </summary>
     public int HeaderHeight
     {
-        get => (int)GetValue(HeaderHeightProperty);
-        set => SetValue(HeaderHeightProperty, value);
+        get => (int)this.GetValue(HeaderHeightProperty);
+        set => this.SetValue(HeaderHeightProperty, value);
     }
 
     /// <summary>
@@ -525,8 +521,8 @@ public partial class DataGrid
     /// </summary>
     public bool IsSortable
     {
-        get => (bool)GetValue(IsSortableProperty);
-        set => SetValue(IsSortableProperty, value);
+        get => (bool)this.GetValue(IsSortableProperty);
+        set => this.SetValue(IsSortableProperty, value);
     }
 
     /// <summary>
@@ -534,8 +530,8 @@ public partial class DataGrid
     /// </summary>
     public bool SelectionEnabled
     {
-        get => (bool)GetValue(SelectionEnabledProperty);
-        set => SetValue(SelectionEnabledProperty, value);
+        get => (bool)this.GetValue(SelectionEnabledProperty);
+        set => this.SetValue(SelectionEnabledProperty, value);
     }
 
     /// <summary>
@@ -543,8 +539,8 @@ public partial class DataGrid
     /// </summary>
     public object? SelectedItem
     {
-        get => GetValue(SelectedItemProperty);
-        set => SetValue(SelectedItemProperty, value);
+        get => this.GetValue(SelectedItemProperty);
+        set => this.SetValue(SelectedItemProperty, value);
     }
 
     /// <summary>
@@ -552,8 +548,8 @@ public partial class DataGrid
     /// </summary>
     public ICommand PullToRefreshCommand
     {
-        get => (ICommand)GetValue(PullToRefreshCommandProperty);
-        set => SetValue(PullToRefreshCommandProperty, value);
+        get => (ICommand)this.GetValue(PullToRefreshCommandProperty);
+        set => this.SetValue(PullToRefreshCommandProperty, value);
     }
 
     /// <summary>
@@ -561,8 +557,8 @@ public partial class DataGrid
     /// </summary>
     public bool IsRefreshing
     {
-        get => (bool)GetValue(IsRefreshingProperty);
-        set => SetValue(IsRefreshingProperty, value);
+        get => (bool)this.GetValue(IsRefreshingProperty);
+        set => this.SetValue(IsRefreshingProperty, value);
     }
 
     /// <summary>
@@ -570,8 +566,8 @@ public partial class DataGrid
     /// </summary>
     public bool RefreshingEnabled
     {
-        get => (bool)GetValue(RefreshingEnabledProperty);
-        set => SetValue(RefreshingEnabledProperty, value);
+        get => (bool)this.GetValue(RefreshingEnabledProperty);
+        set => this.SetValue(RefreshingEnabledProperty, value);
     }
 
     /// <summary>
@@ -579,8 +575,8 @@ public partial class DataGrid
     /// </summary>
     public Thickness BorderThickness
     {
-        get => (Thickness)GetValue(BorderThicknessProperty);
-        set => SetValue(BorderThicknessProperty, value);
+        get => (Thickness)this.GetValue(BorderThicknessProperty);
+        set => this.SetValue(BorderThicknessProperty, value);
     }
 
     /// <summary>
@@ -589,8 +585,8 @@ public partial class DataGrid
     /// </summary>
     public bool HeaderBordersVisible
     {
-        get => (bool)GetValue(HeaderBordersVisibleProperty);
-        set => SetValue(HeaderBordersVisibleProperty, value);
+        get => (bool)this.GetValue(HeaderBordersVisibleProperty);
+        set => this.SetValue(HeaderBordersVisibleProperty, value);
     }
 
     /// <summary>
@@ -598,8 +594,8 @@ public partial class DataGrid
     /// </summary>
     public SortData SortedColumnIndex
     {
-        get => (SortData)GetValue(SortedColumnIndexProperty);
-        set => SetValue(SortedColumnIndexProperty, value);
+        get => (SortData)this.GetValue(SortedColumnIndexProperty);
+        set => this.SetValue(SortedColumnIndexProperty, value);
     }
 
     /// <summary>
@@ -608,8 +604,8 @@ public partial class DataGrid
     /// </summary>
     public Style HeaderLabelStyle
     {
-        get => (Style)GetValue(HeaderLabelStyleProperty);
-        set => SetValue(HeaderLabelStyleProperty, value);
+        get => (Style)this.GetValue(HeaderLabelStyleProperty);
+        set => this.SetValue(HeaderLabelStyleProperty, value);
     }
 
     /// <summary>
@@ -617,8 +613,8 @@ public partial class DataGrid
     /// </summary>
     public Polygon SortIcon
     {
-        get => (Polygon)GetValue(SortIconProperty);
-        set => SetValue(SortIconProperty, value);
+        get => (Polygon)this.GetValue(SortIconProperty);
+        set => this.SetValue(SortIconProperty, value);
     }
 
     /// <summary>
@@ -627,8 +623,8 @@ public partial class DataGrid
     /// </summary>
     public Style SortIconStyle
     {
-        get => (Style)GetValue(SortIconStyleProperty);
-        set => SetValue(SortIconStyleProperty, value);
+        get => (Style)this.GetValue(SortIconStyleProperty);
+        set => this.SetValue(SortIconStyleProperty, value);
     }
 
     /// <summary>
@@ -636,11 +632,11 @@ public partial class DataGrid
     /// </summary>
     public View NoDataView
     {
-        get => (View)GetValue(NoDataViewProperty);
-        set => SetValue(NoDataViewProperty, value);
+        get => (View)this.GetValue(NoDataViewProperty);
+        set => this.SetValue(NoDataViewProperty, value);
     }
 
-    #endregion
+    #endregion Properties
 
     #region UI Methods
 
@@ -648,27 +644,27 @@ public partial class DataGrid
     {
         base.OnParentSet();
 
-        if (SelectionEnabled)
+        if (this.SelectionEnabled)
         {
-            if (Parent is null)
+            if (this.Parent is null)
             {
-                _collectionView.SelectionChanged -= OnSelectionChanged;
+                this._collectionView.SelectionChanged -= this.OnSelectionChanged;
             }
             else
             {
-                _collectionView.SelectionChanged += OnSelectionChanged;
+                this._collectionView.SelectionChanged += this.OnSelectionChanged;
             }
         }
 
-        if (RefreshingEnabled)
+        if (this.RefreshingEnabled)
         {
-            if (Parent is null)
+            if (this.Parent is null)
             {
-                _refreshView.Refreshing -= OnRefreshing;
+                this._refreshView.Refreshing -= this.OnRefreshing;
             }
             else
             {
-                _refreshView.Refreshing += OnRefreshing;
+                this._refreshView.Refreshing += this.OnRefreshing;
             }
         }
     }
@@ -676,59 +672,56 @@ public partial class DataGrid
     protected override void OnBindingContextChanged()
     {
         base.OnBindingContextChanged();
-        InitHeaderView();
+        this.InitHeaderView();
     }
 
-    private void OnRefreshing(object? sender, EventArgs e)
-    {
-        _refreshingEventManager.HandleEvent(this, e, nameof(Refreshing));
-    }
+    private void OnRefreshing(object? sender, EventArgs e) => this.refreshingEventManager.HandleEvent(this, e, nameof(Refreshing));
 
     private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
-        SelectedItem = _collectionView.SelectedItem;
+        this.SelectedItem = this._collectionView.SelectedItem;
 
-        _itemSelectedEventManager.HandleEvent(this, e, nameof(ItemSelected));
+        this.itemSelectedEventManager.HandleEvent(this, e, nameof(ItemSelected));
     }
 
     internal void Reload()
     {
-        if (_internalItems is not null)
+        if (this.internalItems is not null)
         {
-            InternalItems = new List<object>(_internalItems);
+            this.InternalItems = new List<object>(this.internalItems);
         }
-        RefreshHeaderColumnWidths();
+        this.RefreshHeaderColumnWidths();
     }
 
     private void RefreshHeaderColumnWidths()
     {
-        for (int i = 0; i < Columns.Count; i++)
+        for (var i = 0; i < this.Columns.Count; i++)
         {
-            var column = Columns[i];
+            var column = this.Columns[i];
 
-            _headerView.ColumnDefinitions[i] = column.ColumnDefinition;
+            this._headerView.ColumnDefinitions[i] = column.ColumnDefinition;
         }
     }
 
-    #endregion
+    #endregion UI Methods
 
     #region Header Creation Methods
 
     private View GetHeaderViewForColumn(DataGridColumn column, int index)
     {
         column.HeaderLabel.Style = column.HeaderLabelStyle ??
-                                   HeaderLabelStyle ?? (Style)_headerView.Resources["HeaderDefaultStyle"];
+                                   this.HeaderLabelStyle ?? (Style)this._headerView.Resources["HeaderDefaultStyle"];
 
-        if (IsSortable && column.IsSortable(this) && column.SortingEnabled)
+        if (this.IsSortable && column.IsSortable(this) && column.SortingEnabled)
         {
-            column.SortingIcon.Style = SortIconStyle ?? (Style)_headerView.Resources["SortIconStyle"];
-            column.SortingIconContainer.HeightRequest = HeaderHeight * 0.3;
-            column.SortingIconContainer.WidthRequest = HeaderHeight * 0.3;
+            column.SortingIcon.Style = this.SortIconStyle ?? (Style)this._headerView.Resources["SortIconStyle"];
+            column.SortingIconContainer.HeightRequest = this.HeaderHeight * 0.3;
+            column.SortingIconContainer.WidthRequest = this.HeaderHeight * 0.3;
 
             var grid = new Grid
             {
                 ColumnSpacing = 0,
-                Padding = new(0,0,4,0),
+                Padding = new(0, 0, 4, 0),
                 ColumnDefinitions = new()
                 {
                     new() { Width = new(1, GridUnitType.Star) },
@@ -741,11 +734,11 @@ public partial class DataGrid
                     {
                         Command = new Command(() =>
                         {
-                            var order = _sortingOrders[index] == SortingOrder.Ascendant
+                            var order = this.sortingOrders[index] == SortingOrder.Ascendant
                                 ? SortingOrder.Descendant
                                 : SortingOrder.Ascendant;
 
-                            SortedColumnIndex = new(index, order);
+                            this.SortedColumnIndex = new(index, order);
                         }, () => column.SortingEnabled)
                     }
                 }
@@ -763,50 +756,50 @@ public partial class DataGrid
 
     internal void InitHeaderView()
     {
-        SetColumnsBindingContext();
+        this.SetColumnsBindingContext();
 
-        _headerView.Children.Clear();
-        _headerView.ColumnDefinitions.Clear();
-        _sortingOrders.Clear();
+        this._headerView.Children.Clear();
+        this._headerView.ColumnDefinitions.Clear();
+        this.sortingOrders.Clear();
 
-        _headerView.Padding = new(BorderThickness.Left, BorderThickness.Top, BorderThickness.Right, 0);
-        _headerView.ColumnSpacing = BorderThickness.HorizontalThickness;
+        this._headerView.Padding = new(this.BorderThickness.Left, this.BorderThickness.Top, this.BorderThickness.Right, 0);
+        this._headerView.ColumnSpacing = this.BorderThickness.HorizontalThickness;
 
-        if (Columns != null)
+        if (this.Columns != null)
         {
-            for (var i = 0; i < Columns.Count; i++)
+            for (var i = 0; i < this.Columns.Count; i++)
             {
-                var col = Columns[i];
+                var col = this.Columns[i];
 
                 col.ColumnDefinition ??= new(col.Width);
 
-                _headerView.ColumnDefinitions.Add(col.ColumnDefinition);
+                this._headerView.ColumnDefinitions.Add(col.ColumnDefinition);
 
-                var cell = GetHeaderViewForColumn(col, i);
+                var cell = this.GetHeaderViewForColumn(col, i);
 
-                cell.SetBinding(BackgroundColorProperty, new Binding(nameof(HeaderBackground), source:this));
+                cell.SetBinding(BackgroundColorProperty, new Binding(nameof(this.HeaderBackground), source: this));
 
                 cell.SetBinding(IsVisibleProperty,
                     new Binding(nameof(col.IsVisible), BindingMode.OneWay, source: col));
 
                 Grid.SetColumn(cell, i);
-                _headerView.Children.Add(cell);
+                this._headerView.Children.Add(cell);
 
-                _sortingOrders.Add(i, SortingOrder.None);
+                this.sortingOrders.Add(i, SortingOrder.None);
             }
         }
     }
 
     private void SetColumnsBindingContext()
     {
-        if (Columns != null)
+        if (this.Columns != null)
         {
-            foreach (var c in Columns)
+            foreach (var c in this.Columns)
             {
-                c.BindingContext = BindingContext;
+                c.BindingContext = this.BindingContext;
             }
         }
     }
 
-    #endregion
+    #endregion Header Creation Methods
 }

--- a/Maui.DataGrid/DataGridColumn.cs
+++ b/Maui.DataGrid/DataGridColumn.cs
@@ -1,22 +1,22 @@
-﻿using Microsoft.Maui.Controls.Shapes;
-using System.ComponentModel;
+﻿namespace Maui.DataGrid;
 
-namespace Maui.DataGrid;
+using Microsoft.Maui.Controls.Shapes;
+using System.ComponentModel;
 
 /// <summary>
 /// Specifies each column of the DataGrid.
 /// </summary>
 public class DataGridColumn : BindableObject, IDefinition
 {
-    private bool? _isSortable;
-    private ColumnDefinition? _columnDefinition;
-    private readonly ColumnDefinition _invisibleColumnDefinition = new(0);
+    private bool? isSortable;
+    private ColumnDefinition? columnDefinition;
+    private readonly ColumnDefinition invisibleColumnDefinition = new(0);
 
     public DataGridColumn()
     {
-        HeaderLabel = new();
-        SortingIcon = new();
-        SortingIconContainer = new ContentView
+        this.HeaderLabel = new();
+        this.SortingIcon = new();
+        this.SortingIconContainer = new ContentView
         {
             IsVisible = false,
             Content = SortingIcon,
@@ -25,18 +25,15 @@ public class DataGridColumn : BindableObject, IDefinition
         };
     }
 
-    readonly WeakEventManager _sizeChangedEventManager = new();
+    private readonly WeakEventManager sizeChangedEventManager = new();
 
     public event EventHandler SizeChanged
     {
-        add => _sizeChangedEventManager.AddEventHandler(value);
-        remove => _sizeChangedEventManager.RemoveEventHandler(value);
+        add => this.sizeChangedEventManager.AddEventHandler(value);
+        remove => this.sizeChangedEventManager.RemoveEventHandler(value);
     }
 
-    private void OnSizeChanged()
-    {
-        _sizeChangedEventManager.HandleEvent(this, EventArgs.Empty, string.Empty);
-    }
+    private void OnSizeChanged() => this.sizeChangedEventManager.HandleEvent(this, EventArgs.Empty, string.Empty);
 
     #region Bindable Properties
 
@@ -105,7 +102,7 @@ public class DataGridColumn : BindableObject, IDefinition
                 }
             });
 
-    #endregion
+    #endregion Bindable Properties
 
     #region properties
 
@@ -113,28 +110,28 @@ public class DataGridColumn : BindableObject, IDefinition
     {
         get
         {
-            if (!IsVisible)
+            if (!this.IsVisible)
             {
-                return _invisibleColumnDefinition;
+                return this.invisibleColumnDefinition;
             }
 
-            return _columnDefinition;
+            return this.columnDefinition;
         }
 
-        internal set => _columnDefinition = value;
+        internal set => this.columnDefinition = value;
     }
 
     /// <summary>
-    /// Width of the column. Like Grid, you can use <code>Absolute, star, Auto</code> as unit.
+    /// Width of the column. Like Grid, you can use <c>Absolute, star, Auto</c> as unit.
     /// </summary>
     [TypeConverter(typeof(GridLengthTypeConverter))]
     public GridLength Width
     {
-        get => (GridLength)GetValue(WidthProperty);
+        get => (GridLength)this.GetValue(WidthProperty);
         set
         {
-            SetValue(WidthProperty, value);
-            ColumnDefinition = new(value);
+            this.SetValue(WidthProperty, value);
+            this.ColumnDefinition = new(value);
         }
     }
 
@@ -143,8 +140,8 @@ public class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public string Title
     {
-        get => (string)GetValue(TitleProperty);
-        set => SetValue(TitleProperty, value);
+        get => (string)this.GetValue(TitleProperty);
+        set => this.SetValue(TitleProperty, value);
     }
 
     /// <summary>
@@ -162,8 +159,8 @@ public class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public FormattedString FormattedTitle
     {
-        get => (string)GetValue(FormattedTitleProperty);
-        set => SetValue(FormattedTitleProperty, value);
+        get => (string)this.GetValue(FormattedTitleProperty);
+        set => this.SetValue(FormattedTitleProperty, value);
     }
 
     /// <summary>
@@ -171,8 +168,8 @@ public class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public string PropertyName
     {
-        get => (string)GetValue(PropertyNameProperty);
-        set => SetValue(PropertyNameProperty, value);
+        get => (string)this.GetValue(PropertyNameProperty);
+        set => this.SetValue(PropertyNameProperty, value);
     }
 
     /// <summary>
@@ -180,27 +177,26 @@ public class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public bool IsVisible
     {
-        get => (bool)GetValue(IsVisibleProperty);
-        set => SetValue(IsVisibleProperty, value);
+        get => (bool)this.GetValue(IsVisibleProperty);
+        set => this.SetValue(IsVisibleProperty, value);
     }
-
 
     /// <summary>
     /// String format for the cell
     /// </summary>
     public string StringFormat
     {
-        get => (string)GetValue(StringFormatProperty);
-        set => SetValue(StringFormatProperty, value);
+        get => (string)this.GetValue(StringFormatProperty);
+        set => this.SetValue(StringFormatProperty, value);
     }
 
     /// <summary>
-    /// Cell template. Default value is  <c>Label</c> with binding <code>PropertyName</code>
+    /// Cell template. Default value is <c>Label</c> with binding <c>PropertyName</c>
     /// </summary>
     public DataTemplate CellTemplate
     {
-        get => (DataTemplate)GetValue(CellTemplateProperty);
-        set => SetValue(CellTemplateProperty, value);
+        get => (DataTemplate)this.GetValue(CellTemplateProperty);
+        set => this.SetValue(CellTemplateProperty, value);
     }
 
     internal Polygon SortingIcon { get; }
@@ -212,26 +208,26 @@ public class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public LineBreakMode LineBreakMode
     {
-        get => (LineBreakMode)GetValue(LineBreakModeProperty);
-        set => SetValue(LineBreakModeProperty, value);
+        get => (LineBreakMode)this.GetValue(LineBreakModeProperty);
+        set => this.SetValue(LineBreakModeProperty, value);
     }
 
     /// <summary>
-    /// Horizontal alignment of the cell content 
+    /// Horizontal alignment of the cell content
     /// </summary>
     public LayoutOptions HorizontalContentAlignment
     {
-        get => (LayoutOptions)GetValue(HorizontalContentAlignmentProperty);
-        set => SetValue(HorizontalContentAlignmentProperty, value);
+        get => (LayoutOptions)this.GetValue(HorizontalContentAlignmentProperty);
+        set => this.SetValue(HorizontalContentAlignmentProperty, value);
     }
 
     /// <summary>
-    /// Vertical alignment of the cell content 
+    /// Vertical alignment of the cell content
     /// </summary>
     public LayoutOptions VerticalContentAlignment
     {
-        get => (LayoutOptions)GetValue(VerticalContentAlignmentProperty);
-        set => SetValue(VerticalContentAlignmentProperty, value);
+        get => (LayoutOptions)this.GetValue(VerticalContentAlignmentProperty);
+        set => this.SetValue(VerticalContentAlignmentProperty, value);
     }
 
     /// <summary>
@@ -240,47 +236,48 @@ public class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public bool SortingEnabled
     {
-        get => (bool)GetValue(SortingEnabledProperty);
-        set => SetValue(SortingEnabledProperty, value);
+        get => (bool)this.GetValue(SortingEnabledProperty);
+        set => this.SetValue(SortingEnabledProperty, value);
     }
 
     /// <summary>
     /// Determines via reflection if the column's data type is sortable.
     /// If you want to disable sorting for specific column please use <c>SortingEnabled</c> property
     /// </summary>
+    /// <param name="dataGrid"></param>
     public bool IsSortable(DataGrid dataGrid)
     {
-        if (_isSortable is not null)
+        if (this.isSortable is not null)
         {
-            return _isSortable.Value;
+            return this.isSortable.Value;
         }
 
         try
         {
             var listItemType = dataGrid.ItemsSource.GetType().GetGenericArguments().Single();
-            var columnDataType = listItemType.GetProperty(PropertyName)?.PropertyType;
+            var columnDataType = listItemType.GetProperty(this.PropertyName)?.PropertyType;
 
             if (columnDataType is not null)
             {
-                _isSortable = typeof(IComparable).IsAssignableFrom(columnDataType);
+                this.isSortable = typeof(IComparable).IsAssignableFrom(columnDataType);
             }
         }
         catch
         {
-            _isSortable = false;
+            this.isSortable = false;
         }
 
-        return _isSortable ?? false;
+        return this.isSortable ?? false;
     }
 
     /// <summary>
-    /// Label Style of the header. <c>TargetType</c> must be Label. 
+    /// Label Style of the header. <c>TargetType</c> must be Label.
     /// </summary>
     public Style HeaderLabelStyle
     {
-        get => (Style)GetValue(HeaderLabelStyleProperty);
-        set => SetValue(HeaderLabelStyleProperty, value);
+        get => (Style)this.GetValue(HeaderLabelStyleProperty);
+        set => this.SetValue(HeaderLabelStyleProperty, value);
     }
 
-    #endregion
+    #endregion properties
 }

--- a/Maui.DataGrid/DataGridRow.cs
+++ b/Maui.DataGrid/DataGridRow.cs
@@ -7,21 +7,21 @@ internal sealed class DataGridRow : Grid
 {
     #region Fields
 
-    private Color _bgColor;
-    private Color _textColor;
-    private bool _hasSelected;
+    private Color? bgColor;
+    private Color? textColor;
+    private bool hasSelected;
 
-    #endregion
+    #endregion Fields
 
     #region properties
 
     public DataGrid DataGrid
     {
-        get => (DataGrid)GetValue(DataGridProperty);
-        set => SetValue(DataGridProperty, value);
+        get => (DataGrid)this.GetValue(DataGridProperty);
+        set => this.SetValue(DataGridProperty, value);
     }
 
-    #endregion
+    #endregion properties
 
     #region Bindable Properties
 
@@ -29,28 +29,28 @@ internal sealed class DataGridRow : Grid
         BindableProperty.Create(nameof(DataGrid), typeof(DataGrid), typeof(DataGridRow), null,
             propertyChanged: (b, _, _) => ((DataGridRow)b).CreateView());
 
-    #endregion
+    #endregion Bindable Properties
 
     #region Methods
 
     private void CreateView()
     {
-        ColumnDefinitions.Clear();
-        Children.Clear();
+        this.ColumnDefinitions.Clear();
+        this.Children.Clear();
 
-        BackgroundColor = DataGrid.BorderColor;
+        this.BackgroundColor = this.DataGrid.BorderColor;
 
-        var borderThickness = DataGrid.BorderThickness;
+        var borderThickness = this.DataGrid.BorderThickness;
 
-        Padding = new(borderThickness.Left, borderThickness.Top, borderThickness.Right, 0);
-        ColumnSpacing = borderThickness.HorizontalThickness;
-        Margin = new Thickness(0, 0, 0, borderThickness.Bottom); // Row Spacing
+        this.Padding = new(borderThickness.Left, borderThickness.Top, borderThickness.Right, 0);
+        this.ColumnSpacing = borderThickness.HorizontalThickness;
+        this.Margin = new Thickness(0, 0, 0, borderThickness.Bottom); // Row Spacing
 
-        for (int i = 0; i < DataGrid.Columns.Count; i++)
+        for (var i = 0; i < this.DataGrid.Columns.Count; i++)
         {
-            DataGridColumn col = DataGrid.Columns[i];
+            var col = this.DataGrid.Columns[i];
 
-            ColumnDefinitions.Add(col.ColumnDefinition);
+            this.ColumnDefinitions.Add(col.ColumnDefinition);
 
             View cell;
 
@@ -60,15 +60,15 @@ internal sealed class DataGridRow : Grid
                 if (col.PropertyName != null)
                 {
                     cell.SetBinding(BindingContextProperty,
-                        new Binding(col.PropertyName, source: BindingContext));
+                        new Binding(col.PropertyName, source: this.BindingContext));
                 }
             }
             else
             {
                 cell = new Label
                 {
-                    TextColor = _textColor,
-                    BackgroundColor = _bgColor,
+                    TextColor = textColor,
+                    BackgroundColor = bgColor,
                     VerticalOptions = LayoutOptions.Fill,
                     HorizontalOptions = LayoutOptions.Fill,
                     VerticalTextAlignment = col.VerticalContentAlignment.ToTextAlignment(),
@@ -78,40 +78,40 @@ internal sealed class DataGridRow : Grid
                 cell.SetBinding(Label.TextProperty,
                     new Binding(col.PropertyName, BindingMode.Default, stringFormat: col.StringFormat));
                 cell.SetBinding(Label.FontSizeProperty,
-                    new Binding(DataGrid.FontSizeProperty.PropertyName, BindingMode.Default, source: DataGrid));
+                    new Binding(DataGrid.FontSizeProperty.PropertyName, BindingMode.Default, source: this.DataGrid));
                 cell.SetBinding(Label.FontFamilyProperty,
-                    new Binding(DataGrid.FontFamilyProperty.PropertyName, BindingMode.Default, source: DataGrid));
+                    new Binding(DataGrid.FontFamilyProperty.PropertyName, BindingMode.Default, source: this.DataGrid));
             }
 
             cell.SetBinding(IsVisibleProperty,
                 new Binding(nameof(col.IsVisible), BindingMode.OneWay, source: col));
 
             SetColumn((BindableObject)cell, i);
-            Children.Add(cell);
+            this.Children.Add(cell);
         }
 
-        UpdateBackgroundColor();
+        this.UpdateBackgroundColor();
     }
 
     private void UpdateBackgroundColor()
     {
-        _hasSelected = DataGrid?.SelectedItem == BindingContext;
-        var actualIndex = DataGrid?.InternalItems?.IndexOf(BindingContext) ?? -1;
+        this.hasSelected = this.DataGrid?.SelectedItem == this.BindingContext;
+        var actualIndex = this.DataGrid?.InternalItems?.IndexOf(this.BindingContext) ?? -1;
         if (actualIndex > -1)
         {
-            _bgColor =
-                DataGrid.SelectionEnabled && DataGrid.SelectedItem != null && DataGrid.SelectedItem == BindingContext
-                    ? DataGrid.ActiveRowColor
-                    : DataGrid.RowsBackgroundColorPalette.GetColor(actualIndex, BindingContext);
-            _textColor = DataGrid.RowsTextColorPalette.GetColor(actualIndex, BindingContext);
+            this.bgColor =
+                this.DataGrid?.SelectionEnabled == true && this.DataGrid.SelectedItem != null && this.DataGrid.SelectedItem == this.BindingContext
+                    ? this.DataGrid.ActiveRowColor
+                    : this.DataGrid?.RowsBackgroundColorPalette.GetColor(actualIndex, this.BindingContext);
+            this.textColor = this.DataGrid?.RowsTextColorPalette.GetColor(actualIndex, this.BindingContext);
 
-            ChangeColor(_bgColor, _textColor);
+            this.ChangeColor(this.bgColor, this.textColor);
         }
     }
 
-    private void ChangeColor(Color bgColor, Color textColor)
+    private void ChangeColor(Color? bgColor, Color? textColor)
     {
-        foreach (var v in Children)
+        foreach (var v in this.Children)
         {
             if (v is View view)
             {
@@ -128,33 +128,33 @@ internal sealed class DataGridRow : Grid
     protected override void OnBindingContextChanged()
     {
         base.OnBindingContextChanged();
-        CreateView();
+        this.CreateView();
     }
 
     protected override void OnParentSet()
     {
         base.OnParentSet();
 
-        if (DataGrid.SelectionEnabled)
+        if (this.DataGrid.SelectionEnabled)
         {
-            if (Parent != null)
+            if (this.Parent != null)
             {
-                DataGrid.ItemSelected += DataGrid_ItemSelected;
+                this.DataGrid.ItemSelected += this.DataGrid_ItemSelected;
             }
             else
             {
-                DataGrid.ItemSelected -= DataGrid_ItemSelected;
+                this.DataGrid.ItemSelected -= this.DataGrid_ItemSelected;
             }
         }
     }
 
-    private void DataGrid_ItemSelected(object sender, SelectionChangedEventArgs e)
+    private void DataGrid_ItemSelected(object? sender, SelectionChangedEventArgs e)
     {
-        if (DataGrid.SelectionEnabled && (e.CurrentSelection[^1] == BindingContext || _hasSelected))
+        if (this.DataGrid.SelectionEnabled && (e.CurrentSelection[^1] == this.BindingContext || this.hasSelected))
         {
-            UpdateBackgroundColor();
+            this.UpdateBackgroundColor();
         }
     }
 
-    #endregion
+    #endregion Methods
 }

--- a/Maui.DataGrid/PaletteCollection.cs
+++ b/Maui.DataGrid/PaletteCollection.cs
@@ -11,8 +11,5 @@ public sealed class PaletteCollection : List<Color>, IColorProvider
     /// <param name="rowIndex">Index of the row based on DataSource</param>
     /// <param name="item">Item on the index</param>
     /// <returns>Color for the row</returns>
-    public Color GetColor(int rowIndex, object item)
-    {
-        return Count > 0 ? this.ElementAt(rowIndex % Count) : default;
-    }
+    public Color GetColor(int rowIndex, object item) => this.Count > 0 ? this.ElementAt(rowIndex % this.Count) : Colors.White;
 }

--- a/Maui.DataGrid/Platforms/Android/PlatformClass.cs
+++ b/Maui.DataGrid/Platforms/Android/PlatformClass.cs
@@ -1,7 +1,6 @@
-﻿namespace Maui.DataGrid.Platforms.Android
+﻿namespace Maui.DataGrid.Platforms.Android;
+
+// All the code in this file is only included on Android.
+public class PlatformClass
 {
-  // All the code in this file is only included on Android.
-  public class PlatformClass
-  {
-  }
 }

--- a/Maui.DataGrid/Platforms/MacCatalyst/PlatformClass.cs
+++ b/Maui.DataGrid/Platforms/MacCatalyst/PlatformClass.cs
@@ -1,7 +1,6 @@
-﻿namespace Maui.DataGrid.Platforms.MacCatalyst
+﻿namespace Maui.DataGrid.Platforms.MacCatalyst;
+
+// All the code in this file is only included on Mac Catalyst.
+public class PlatformClass
 {
-  // All the code in this file is only included on Mac Catalyst.
-  public class PlatformClass
-  {
-  }
 }

--- a/Maui.DataGrid/Platforms/Tizen/PlatformClass1.cs
+++ b/Maui.DataGrid/Platforms/Tizen/PlatformClass1.cs
@@ -1,9 +1,8 @@
-﻿using System;
+﻿namespace Maui.DataGrid;
 
-namespace Maui.DataGrid
+using System;
+
+// All the code in this file is only included on Tizen.
+public class PlatformClass
 {
-  // All the code in this file is only included on Tizen.
-  public class PlatformClass
-  {
-  }
 }

--- a/Maui.DataGrid/Platforms/Windows/PlatformClass.cs
+++ b/Maui.DataGrid/Platforms/Windows/PlatformClass.cs
@@ -1,7 +1,6 @@
-﻿namespace Maui.DataGrid.Platforms.Windows
+﻿namespace Maui.DataGrid.Platforms.Windows;
+
+// All the code in this file is only included on Windows.
+public class PlatformClass
 {
-  // All the code in this file is only included on Windows.
-  public class PlatformClass
-  {
-  }
 }

--- a/Maui.DataGrid/Platforms/iOS/PlatformClass.cs
+++ b/Maui.DataGrid/Platforms/iOS/PlatformClass.cs
@@ -1,7 +1,6 @@
-﻿namespace Maui.DataGrid.Platforms.iOS
+﻿namespace Maui.DataGrid.Platforms.iOS;
+
+// All the code in this file is only included on iOS.
+public class PlatformClass
 {
-  // All the code in this file is only included on iOS.
-  public class PlatformClass
-  {
-  }
 }

--- a/Maui.DataGrid/SortData.cs
+++ b/Maui.DataGrid/SortData.cs
@@ -1,6 +1,6 @@
-﻿using System.ComponentModel;
-
 namespace Maui.DataGrid;
+
+using System.ComponentModel;
 
 /// <summary>
 /// Creates SortData for DataGrid
@@ -8,20 +8,17 @@ namespace Maui.DataGrid;
 [TypeConverter(typeof(SortDataTypeConverter))]
 public class SortData
 {
-    public static implicit operator SortData(int index)
+    public static implicit operator SortData(int index) => new()
     {
-        return new SortData
-        {
-            Index = Math.Abs(index),
-            Order = index < 0 ? SortingOrder.Descendant : SortingOrder.Ascendant
-        };
-    }
+        Index = Math.Abs(index),
+        Order = index < 0 ? SortingOrder.Descendant : SortingOrder.Ascendant
+    };
 
     public override bool Equals(object? obj)
     {
         if (obj is SortData other)
         {
-            return other.Index == Index && other.Order == Order;
+            return other.Index == this.Index && other.Order == this.Order;
         }
 
         return false;
@@ -34,11 +31,11 @@ public class SortData
 
     public SortData(int index, SortingOrder order)
     {
-        Index = index;
-        Order = order;
+        this.Index = index;
+        this.Order = order;
     }
 
-    #endregion
+    #endregion ctor
 
     #region Properties
 
@@ -52,10 +49,7 @@ public class SortData
     /// </summary>
     public int Index { get; set; }
 
-    #endregion
+    #endregion Properties
 
-    public override int GetHashCode()
-    {
-        throw new NotImplementedException();
-    }
+    public override int GetHashCode() => throw new NotImplementedException();
 }

--- a/Maui.DataGrid/SortDataTypeConverter.cs
+++ b/Maui.DataGrid/SortDataTypeConverter.cs
@@ -1,7 +1,7 @@
-﻿using System.ComponentModel;
-using System.Globalization;
+﻿namespace Maui.DataGrid;
 
-namespace Maui.DataGrid;
+using System.ComponentModel;
+using System.Globalization;
 
 /// <summary>
 /// Converts string to <c>SortingOrder</c> enum.
@@ -10,7 +10,7 @@ public class SortDataTypeConverter : TypeConverter
 {
     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
     {
-        if (int.TryParse(value?.ToString(), out var index))
+        if (int.TryParse(value.ToString(), out var index))
         {
             return (SortData)index;
         }

--- a/Maui.DataGrid/Utils/LayoutOptionsExtensions.cs
+++ b/Maui.DataGrid/Utils/LayoutOptionsExtensions.cs
@@ -2,13 +2,10 @@
 
 internal static class LayoutOptionsExtensions
 {
-    internal static TextAlignment ToTextAlignment(this LayoutOptions layoutAlignment)
+    internal static TextAlignment ToTextAlignment(this LayoutOptions layoutAlignment) => layoutAlignment.Alignment switch
     {
-        return layoutAlignment.Alignment switch
-        {
-            LayoutAlignment.Start => TextAlignment.Start,
-            LayoutAlignment.End => TextAlignment.End,
-            _ => TextAlignment.Center,
-        };
-    }
+        LayoutAlignment.Start => TextAlignment.Start,
+        LayoutAlignment.End => TextAlignment.End,
+        _ => TextAlignment.Center,
+    };
 }

--- a/Maui.DataGrid/Utils/ReflectionUtils.cs
+++ b/Maui.DataGrid/Utils/ReflectionUtils.cs
@@ -1,6 +1,7 @@
-﻿using System.Reflection;
+﻿namespace Maui.DataGrid.Utils;
 
-namespace Maui.DataGrid.Utils;
+using System.Globalization;
+using System.Reflection;
 
 internal static class ReflectionUtils
 {
@@ -53,14 +54,13 @@ internal static class ReflectionUtils
         var indexOperator = obj?.GetType().GetRuntimeProperty("Item");
         if (indexOperator != null)
         {
-            var indexParameters = indexOperator.GetIndexParameters();
             // Looking up suitable index operator
-            foreach (var parameter in indexParameters)
+            foreach (var parameter in indexOperator.GetIndexParameters())
             {
                 var isIndexOpWorked = true;
                 try
                 {
-                    var indexVal = Convert.ChangeType(index, parameter.ParameterType);
+                    var indexVal = Convert.ChangeType(index, parameter.ParameterType, CultureInfo.InvariantCulture);
                     result = indexOperator.GetValue(obj, new[] { indexVal });
                 }
                 catch


### PR DESCRIPTION
This adds the .editorconfig file from [this repository](https://github.com/RehanSaeed/EditorConfig). EditorConfig helps align coding styles, using IDE-based enforcement, to ensure consistency and cleaner diffs.

This editorconfig file closely matches the official StyleCop rules. Interestingly, a lot of community conventions within C# are different from what StyleCop recommends. But every rule has some logic behind it.

For instance, requiring the use of "this" ensures that it is always explicit whether you are working with an instance variable, and then makes underscore prefixes redundant. Takes a second to get used to, but of course the rules are configurable.

I used automatic solution-wide refactorings to achieve this PR, and tested that it works with the sample project.

I will make another PR afterwards to add the official StyleCop analyzers at designtime, which have even more rules.

Fixes https://github.com/akgulebubekir/Maui.DataGrid/issues/44