### PR TITLE
EditorConfig alignment

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -132,14 +132,14 @@ csharp_style_var_for_built_in_types = true:warning
 csharp_style_var_when_type_is_apparent = true:warning
 csharp_style_var_elsewhere = true:warning
 # Expression-bodied members
-csharp_style_expression_bodied_methods = true:warning
-csharp_style_expression_bodied_constructors = true:none
-csharp_style_expression_bodied_operators = true:warning
-csharp_style_expression_bodied_properties = true:warning
-csharp_style_expression_bodied_indexers = true:warning
-csharp_style_expression_bodied_accessors = true:warning
-csharp_style_expression_bodied_lambdas = true:warning
-csharp_style_expression_bodied_local_functions = true:warning
+csharp_style_expression_bodied_methods = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors = true:when_on_single_line:none
+csharp_style_expression_bodied_operators = when_on_single_line:suggestion
+csharp_style_expression_bodied_properties = when_on_single_line:suggestion
+csharp_style_expression_bodied_indexers = when_on_single_line:suggestion
+csharp_style_expression_bodied_accessors = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas = when_on_single_line:suggestion
+csharp_style_expression_bodied_local_functions = when_on_single_line:suggestion
 # Pattern matching preferences
 csharp_style_pattern_matching_over_is_with_cast_check = true:warning
 csharp_style_pattern_matching_over_as_with_null_check = true:warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -347,21 +347,28 @@ dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.symbols        
 dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.style                 = disallowed_style
 dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.severity              = error
 
-# Private fields must be camelCase
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
-dotnet_naming_symbols.stylecop_private_fields_group.applicable_accessibilities = private
-dotnet_naming_symbols.stylecop_private_fields_group.applicable_kinds           = field
-dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.symbols     = stylecop_private_fields_group
-dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.style       = camel_case_style
-dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.severity    = warning
+# Define the 'private_fields' symbol group:
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
 
-# Local variables must be camelCase
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
-dotnet_naming_symbols.stylecop_local_fields_group.applicable_accessibilities = local
-dotnet_naming_symbols.stylecop_local_fields_group.applicable_kinds           = local
-dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.symbols     = stylecop_local_fields_group
-dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.style       = camel_case_style
-dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.severity    = silent
+# Define the 'private_static_fields' symbol group
+dotnet_naming_symbols.private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_fields.required_modifiers = static
+
+# Define the 'underscored' naming style
+dotnet_naming_style.underscored.capitalization = camel_case
+dotnet_naming_style.underscored.required_prefix = _
+
+# Define the 'private_fields_underscored' naming rule
+dotnet_naming_rule.private_fields_underscored.symbols = private_fields
+dotnet_naming_rule.private_fields_underscored.style = underscored
+dotnet_naming_rule.private_fields_underscored.severity = error
+
+# Define the 'private_static_fields_none' naming rule
+dotnet_naming_rule.private_static_fields_none.symbols = private_static_fields
+dotnet_naming_rule.private_static_fields_none.style = underscored
+dotnet_naming_rule.private_static_fields_none.severity = none
 
 # This rule should never fire.  However, it's included for at least two purposes:
 # First, it helps to understand, reason about, and root-case certain types of issues, such as bugs in .editorconfig parsers.

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,21 @@ indent_style = space
 indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
+csharp_indent_labels = no_change
+csharp_using_directive_placement = inside_namespace:warning
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_braces = true:warning
+csharp_style_namespace_declarations = file_scoped:warning
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_expression_bodied_methods = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = when_on_single_line:suggestion
+csharp_style_expression_bodied_properties = when_on_single_line:suggestion
+csharp_style_expression_bodied_indexers = when_on_single_line:suggestion
+csharp_style_expression_bodied_accessors = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas = when_on_single_line:suggestion
+csharp_style_expression_bodied_local_functions = when_on_single_line:suggestion
 
 ##########################################
 # File Extension Settings
@@ -81,10 +96,10 @@ dotnet_analyzer_diagnostic.severity = warning
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#net-style-rules
 [*.{cs,csx,cake,vb,vbx}]
 # "this." and "Me." qualifiers
-dotnet_style_qualification_for_field = true:warning
-dotnet_style_qualification_for_property = true:warning
-dotnet_style_qualification_for_method = true:warning
-dotnet_style_qualification_for_event = true:warning
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
 # Language keywords instead of framework type names for type references
 dotnet_style_predefined_type_for_locals_parameters_members = true:warning
 dotnet_style_predefined_type_for_member_access = true:warning
@@ -121,7 +136,7 @@ dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 # If you use StyleCop, you'll need to disable SA1636: File header copyright text should match.
 # dotnet_diagnostic.SA1636.severity = none
 # Undocumented
-dotnet_style_operator_placement_when_wrapping = end_of_line:warning
+dotnet_style_operator_placement_when_wrapping = end_of_line
 csharp_style_prefer_null_check_over_type_check = true:warning
 
 # C# Style Rules
@@ -294,8 +309,8 @@ dotnet_naming_symbols.public_protected_constant_fields_group.applicable_accessib
 dotnet_naming_symbols.public_protected_constant_fields_group.required_modifiers         = const
 dotnet_naming_symbols.public_protected_constant_fields_group.applicable_kinds           = field
 dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.symbols    = public_protected_constant_fields_group
-dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.style      = pascal_case_style
-dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.severity   = warning
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.style = pascal_case_style
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.severity = warning
 
 # All public/protected/protected_internal static readonly fields must be PascalCase
 # https://docs.microsoft.com/dotnet/standard/design-guidelines/field
@@ -303,16 +318,16 @@ dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_a
 dotnet_naming_symbols.public_protected_static_readonly_fields_group.required_modifiers         = static, readonly
 dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_kinds           = field
 dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.symbols    = public_protected_static_readonly_fields_group
-dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.style      = pascal_case_style
-dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.severity   = warning
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.style = pascal_case_style
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.severity = warning
 
 # No other public/protected/protected_internal fields are allowed
 # https://docs.microsoft.com/dotnet/standard/design-guidelines/field
 dotnet_naming_symbols.other_public_protected_fields_group.applicable_accessibilities = public, protected, protected_internal
 dotnet_naming_symbols.other_public_protected_fields_group.applicable_kinds           = field
 dotnet_naming_rule.other_public_protected_fields_disallowed_rule.symbols             = other_public_protected_fields_group
-dotnet_naming_rule.other_public_protected_fields_disallowed_rule.style               = disallowed_style
-dotnet_naming_rule.other_public_protected_fields_disallowed_rule.severity            = error
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.style = disallowed_style
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.severity = error
 
 ##########################################
 # StyleCop Field Naming Rules
@@ -327,8 +342,8 @@ dotnet_naming_symbols.stylecop_constant_fields_group.applicable_accessibilities 
 dotnet_naming_symbols.stylecop_constant_fields_group.required_modifiers         = const
 dotnet_naming_symbols.stylecop_constant_fields_group.applicable_kinds           = field
 dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.symbols    = stylecop_constant_fields_group
-dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.style      = pascal_case_style
-dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.severity   = warning
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.style = pascal_case_style
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.severity = warning
 
 # All static readonly fields must be PascalCase
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
@@ -336,16 +351,16 @@ dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_accessibi
 dotnet_naming_symbols.stylecop_static_readonly_fields_group.required_modifiers         = static, readonly
 dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_kinds           = field
 dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.symbols    = stylecop_static_readonly_fields_group
-dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.style      = pascal_case_style
-dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.severity   = warning
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.style = pascal_case_style
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.severity = warning
 
 # No non-private instance fields are allowed
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
 dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected
 dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_kinds           = field
 dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.symbols               = stylecop_fields_must_be_private_group
-dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.style                 = disallowed_style
-dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.severity              = error
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.style = disallowed_style
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.severity = error
 
 # Define the 'private_fields' symbol group:
 dotnet_naming_symbols.private_fields.applicable_kinds = field
@@ -376,7 +391,7 @@ dotnet_naming_rule.private_static_fields_none.severity = none
 dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_accessibilities = *
 dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_kinds           = field
 dotnet_naming_rule.sanity_check_uncovered_field_case_rule.symbols  = sanity_check_uncovered_field_case_group
-dotnet_naming_rule.sanity_check_uncovered_field_case_rule.style    = internal_error_style
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.style = internal_error_style
 dotnet_naming_rule.sanity_check_uncovered_field_case_rule.severity = error
 
 
@@ -397,29 +412,31 @@ dotnet_naming_rule.sanity_check_uncovered_field_case_rule.severity = error
 #   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-type-members
 dotnet_naming_symbols.element_group.applicable_kinds = namespace, class, enum, struct, delegate, event, method, property
 dotnet_naming_rule.element_rule.symbols              = element_group
-dotnet_naming_rule.element_rule.style                = pascal_case_style
-dotnet_naming_rule.element_rule.severity             = warning
+dotnet_naming_rule.element_rule.style = pascal_case_style
+dotnet_naming_rule.element_rule.severity = warning
 
 # Interfaces use PascalCase and are prefixed with uppercase 'I'
 # https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
 dotnet_naming_symbols.interface_group.applicable_kinds = interface
 dotnet_naming_rule.interface_rule.symbols              = interface_group
-dotnet_naming_rule.interface_rule.style                = prefix_interface_with_i_style
-dotnet_naming_rule.interface_rule.severity             = warning
+dotnet_naming_rule.interface_rule.style = prefix_interface_with_i_style
+dotnet_naming_rule.interface_rule.severity = warning
 
 # Generics Type Parameters use PascalCase and are prefixed with uppercase 'T'
 # https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
 dotnet_naming_symbols.type_parameter_group.applicable_kinds = type_parameter
 dotnet_naming_rule.type_parameter_rule.symbols              = type_parameter_group
-dotnet_naming_rule.type_parameter_rule.style                = prefix_type_parameters_with_t_style
-dotnet_naming_rule.type_parameter_rule.severity             = warning
+dotnet_naming_rule.type_parameter_rule.style = prefix_type_parameters_with_t_style
+dotnet_naming_rule.type_parameter_rule.severity = warning
 
 # Function parameters use camelCase
 # https://docs.microsoft.com/dotnet/standard/design-guidelines/naming-parameters
 dotnet_naming_symbols.parameters_group.applicable_kinds = parameter
 dotnet_naming_rule.parameters_rule.symbols              = parameters_group
-dotnet_naming_rule.parameters_rule.style                = camel_case_style
-dotnet_naming_rule.parameters_rule.severity             = warning
+dotnet_naming_rule.parameters_rule.style = camel_case_style
+dotnet_naming_rule.parameters_rule.severity = warning
+tab_width = 4
+end_of_line = crlf
 
 ##########################################
 # License

--- a/Maui.DataGrid.Sample.sln
+++ b/Maui.DataGrid.Sample.sln
@@ -7,6 +7,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Maui.DataGrid.Sample", "Mau
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Maui.DataGrid", "Maui.DataGrid\Maui.DataGrid.csproj", "{3CAFEEB9-BB8E-40FE-B85B-F0ACD6A66429}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Root Files", "Root Files", "{175C8F2C-B5A2-4AAE-A858-2D4A1E8F073E}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.gitignore = .gitignore
+		LICENSE = LICENSE
+		Maui.DataGrid.Sample.sln.DotSettings = Maui.DataGrid.Sample.sln.DotSettings
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Maui.DataGrid.Sample/App.xaml.cs
+++ b/Maui.DataGrid.Sample/App.xaml.cs
@@ -5,8 +5,8 @@ public partial class App
 {
     public App()
     {
-        this.InitializeComponent();
+        InitializeComponent();
 
-        this.MainPage = new AppShell();
+        MainPage = new AppShell();
     }
 }

--- a/Maui.DataGrid.Sample/AppShell.xaml.cs
+++ b/Maui.DataGrid.Sample/AppShell.xaml.cs
@@ -5,6 +5,6 @@ public partial class AppShell
 {
     public AppShell()
     {
-        this.InitializeComponent();
+        InitializeComponent();
     }
 }

--- a/Maui.DataGrid.Sample/MainPage.xaml.cs
+++ b/Maui.DataGrid.Sample/MainPage.xaml.cs
@@ -9,8 +9,8 @@ public partial class MainPage
 {
     public MainPage()
     {
-        this.InitializeComponent();
-        this.BindingContext = new MainViewModel();
+        InitializeComponent();
+        BindingContext = new MainViewModel();
     }
 }
 

--- a/Maui.DataGrid.Sample/Models/Team.cs
+++ b/Maui.DataGrid.Sample/Models/Team.cs
@@ -33,7 +33,10 @@ public class Streak : IComparable
     }
 
     /// <inheritdoc/>
-    public override string ToString() => $"{Enum.GetName(typeof(Result), this.Result)} {this.NumStreak}";
+    public override string ToString()
+    {
+        return $"{Enum.GetName(typeof(Result), this.Result)} {this.NumStreak}";
+    }
 }
 
 public enum Result

--- a/Maui.DataGrid.Sample/Models/Team.cs
+++ b/Maui.DataGrid.Sample/Models/Team.cs
@@ -22,7 +22,7 @@ public class Streak : IComparable
 
     public int CompareTo(object obj)
     {
-        var score = this.Result == Result.Win ? this.NumStreak : -this.NumStreak;
+        var score = Result == Result.Win ? NumStreak : -NumStreak;
         if (obj is Streak s)
         {
             var otherScore = s.Result == Result.Win ? s.NumStreak : -s.NumStreak;
@@ -35,7 +35,7 @@ public class Streak : IComparable
     /// <inheritdoc/>
     public override string ToString()
     {
-        return $"{Enum.GetName(typeof(Result), this.Result)} {this.NumStreak}";
+        return $"{Enum.GetName(typeof(Result), Result)} {NumStreak}";
     }
 }
 

--- a/Maui.DataGrid.Sample/Platforms/Windows/App.xaml.cs
+++ b/Maui.DataGrid.Sample/Platforms/Windows/App.xaml.cs
@@ -14,7 +14,7 @@ public partial class App : MauiWinUIApplication
     /// </summary>
     public App()
     {
-        this.InitializeComponent();
+        InitializeComponent();
     }
 
     /// <inheritdoc/>

--- a/Maui.DataGrid.Sample/ViewModels/MainViewModel.cs
+++ b/Maui.DataGrid.Sample/ViewModels/MainViewModel.cs
@@ -17,67 +17,67 @@ public class MainViewModel : INotifyPropertyChanged
 
     public MainViewModel()
     {
-        this.Teams = DummyDataProvider.GetTeams();
-        this.RefreshCommand = new Command(this.CmdRefresh);
+        Teams = DummyDataProvider.GetTeams();
+        RefreshCommand = new Command(CmdRefresh);
     }
 
     public List<Team> Teams
     {
-        get => this._teams;
+        get => _teams;
         set
         {
-            this._teams = value;
-            this.OnPropertyChanged(nameof(this.Teams));
+            _teams = value;
+            OnPropertyChanged(nameof(Teams));
         }
     }
 
     public bool HeaderBordersVisible
     {
-        get => this._headerBordersVisible;
+        get => _headerBordersVisible;
         set
         {
-            this._headerBordersVisible = value;
-            this.OnPropertyChanged(nameof(this.HeaderBordersVisible));
+            _headerBordersVisible = value;
+            OnPropertyChanged(nameof(HeaderBordersVisible));
         }
     }
 
     public bool TeamColumnVisible
     {
-        get => this._teamColumnVisible;
+        get => _teamColumnVisible;
         set
         {
-            this._teamColumnVisible = value;
-            this.OnPropertyChanged(nameof(this.TeamColumnVisible));
+            _teamColumnVisible = value;
+            OnPropertyChanged(nameof(TeamColumnVisible));
         }
     }
 
     public bool WinColumnVisible
     {
-        get => this._winColumnVisible;
+        get => _winColumnVisible;
         set
         {
-            this._winColumnVisible = value;
-            this.OnPropertyChanged(nameof(this.WinColumnVisible));
+            _winColumnVisible = value;
+            OnPropertyChanged(nameof(WinColumnVisible));
         }
     }
 
     public Team SelectedTeam
     {
-        get => this._selectedItem;
+        get => _selectedItem;
         set
         {
-            this._selectedItem = value;
+            _selectedItem = value;
             Debug.WriteLine("Team Selected : " + value?.Name);
         }
     }
 
     public bool IsRefreshing
     {
-        get => this._isRefreshing;
+        get => _isRefreshing;
         set
         {
-            this._isRefreshing = value;
-            this.OnPropertyChanged(nameof(this.IsRefreshing));
+            _isRefreshing = value;
+            OnPropertyChanged(nameof(IsRefreshing));
         }
     }
 
@@ -85,10 +85,10 @@ public class MainViewModel : INotifyPropertyChanged
 
     private async void CmdRefresh()
     {
-        this.IsRefreshing = true;
+        IsRefreshing = true;
         // wait 3 secs for demo
         await Task.Delay(3000);
-        this.IsRefreshing = false;
+        IsRefreshing = false;
     }
 
     #region INotifyPropertyChanged implementation

--- a/Maui.DataGrid.Sample/ViewModels/MainViewModel.cs
+++ b/Maui.DataGrid.Sample/ViewModels/MainViewModel.cs
@@ -8,12 +8,12 @@ using Maui.DataGrid.Sample.Utils;
 
 public class MainViewModel : INotifyPropertyChanged
 {
-    private List<Team> teams;
-    private Team selectedItem;
-    private bool isRefreshing;
-    private bool teamColumnVisible = true;
-    private bool winColumnVisible = true;
-    private bool headerBordersVisible = true;
+    private List<Team> _teams;
+    private Team _selectedItem;
+    private bool _isRefreshing;
+    private bool _teamColumnVisible = true;
+    private bool _winColumnVisible = true;
+    private bool _headerBordersVisible = true;
 
     public MainViewModel()
     {
@@ -23,60 +23,60 @@ public class MainViewModel : INotifyPropertyChanged
 
     public List<Team> Teams
     {
-        get => this.teams;
+        get => this._teams;
         set
         {
-            this.teams = value;
+            this._teams = value;
             this.OnPropertyChanged(nameof(this.Teams));
         }
     }
 
     public bool HeaderBordersVisible
     {
-        get => this.headerBordersVisible;
+        get => this._headerBordersVisible;
         set
         {
-            this.headerBordersVisible = value;
+            this._headerBordersVisible = value;
             this.OnPropertyChanged(nameof(this.HeaderBordersVisible));
         }
     }
 
     public bool TeamColumnVisible
     {
-        get => this.teamColumnVisible;
+        get => this._teamColumnVisible;
         set
         {
-            this.teamColumnVisible = value;
+            this._teamColumnVisible = value;
             this.OnPropertyChanged(nameof(this.TeamColumnVisible));
         }
     }
 
     public bool WinColumnVisible
     {
-        get => this.winColumnVisible;
+        get => this._winColumnVisible;
         set
         {
-            this.winColumnVisible = value;
+            this._winColumnVisible = value;
             this.OnPropertyChanged(nameof(this.WinColumnVisible));
         }
     }
 
     public Team SelectedTeam
     {
-        get => this.selectedItem;
+        get => this._selectedItem;
         set
         {
-            this.selectedItem = value;
+            this._selectedItem = value;
             Debug.WriteLine("Team Selected : " + value?.Name);
         }
     }
 
     public bool IsRefreshing
     {
-        get => this.isRefreshing;
+        get => this._isRefreshing;
         set
         {
-            this.isRefreshing = value;
+            this._isRefreshing = value;
             this.OnPropertyChanged(nameof(this.IsRefreshing));
         }
     }

--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -12,22 +12,22 @@ using Font = Microsoft.Maui.Font;
 [XamlCompilation(XamlCompilationOptions.Compile)]
 public partial class DataGrid
 {
-    private readonly Dictionary<int, SortingOrder> sortingOrders;
+    private readonly Dictionary<int, SortingOrder> _sortingOrders;
 
-    private readonly WeakEventManager itemSelectedEventManager = new();
+    private readonly WeakEventManager _itemSelectedEventManager = new();
 
     public event EventHandler<SelectionChangedEventArgs> ItemSelected
     {
-        add => this.itemSelectedEventManager.AddEventHandler(value);
-        remove => this.itemSelectedEventManager.RemoveEventHandler(value);
+        add => this._itemSelectedEventManager.AddEventHandler(value);
+        remove => this._itemSelectedEventManager.RemoveEventHandler(value);
     }
 
-    private readonly WeakEventManager refreshingEventManager = new();
+    private readonly WeakEventManager _refreshingEventManager = new();
 
     public event EventHandler Refreshing
     {
-        add => this.refreshingEventManager.AddEventHandler(value);
-        remove => this.refreshingEventManager.RemoveEventHandler(value);
+        add => this._refreshingEventManager.AddEventHandler(value);
+        remove => this._refreshingEventManager.RemoveEventHandler(value);
     }
 
     #region ctor
@@ -36,7 +36,7 @@ public partial class DataGrid
     {
         this.InitializeComponent();
 
-        this.sortingOrders = new();
+        this._sortingOrders = new();
     }
 
     #endregion ctor
@@ -86,7 +86,7 @@ public partial class DataGrid
         {
             if (i != sortData.Index)
             {
-                this.sortingOrders[i] = SortingOrder.None;
+                this._sortingOrders[i] = SortingOrder.None;
                 this.Columns[i].SortingIconContainer.IsVisible = false;
             }
             else
@@ -95,12 +95,12 @@ public partial class DataGrid
             }
         }
 
-        this.internalItems = items;
+        this._internalItems = items;
 
-        this.sortingOrders[sortData.Index] = order;
+        this._sortingOrders[sortData.Index] = order;
         this.SortedColumnIndex = sortData;
 
-        this._collectionView.ItemsSource = this.internalItems;
+        this._collectionView.ItemsSource = this._internalItems;
     }
 
     #endregion Sorting methods
@@ -447,14 +447,14 @@ public partial class DataGrid
         set => this.SetValue(ItemsSourceProperty, value);
     }
 
-    private IList<object>? internalItems;
+    private IList<object>? _internalItems;
 
     internal IList<object>? InternalItems
     {
-        get => this.internalItems;
+        get => this._internalItems;
         set
         {
-            this.internalItems = value;
+            this._internalItems = value;
 
             if (this.IsSortable && this.SortedColumnIndex != null)
             {
@@ -462,7 +462,7 @@ public partial class DataGrid
             }
             else
             {
-                this._collectionView.ItemsSource = this.internalItems;
+                this._collectionView.ItemsSource = this._internalItems;
             }
         }
     }
@@ -677,20 +677,20 @@ public partial class DataGrid
         this.InitHeaderView();
     }
 
-    private void OnRefreshing(object? sender, EventArgs e) => this.refreshingEventManager.HandleEvent(this, e, nameof(Refreshing));
+    private void OnRefreshing(object? sender, EventArgs e) => this._refreshingEventManager.HandleEvent(this, e, nameof(Refreshing));
 
     private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
         this.SelectedItem = this._collectionView.SelectedItem;
 
-        this.itemSelectedEventManager.HandleEvent(this, e, nameof(ItemSelected));
+        this._itemSelectedEventManager.HandleEvent(this, e, nameof(ItemSelected));
     }
 
     internal void Reload()
     {
-        if (this.internalItems is not null)
+        if (this._internalItems is not null)
         {
-            this.InternalItems = new List<object>(this.internalItems);
+            this.InternalItems = new List<object>(this._internalItems);
         }
         this.RefreshHeaderColumnWidths();
     }
@@ -736,7 +736,7 @@ public partial class DataGrid
                     {
                         Command = new Command(() =>
                         {
-                            var order = this.sortingOrders[index] == SortingOrder.Ascendant
+                            var order = this._sortingOrders[index] == SortingOrder.Ascendant
                                 ? SortingOrder.Descendant
                                 : SortingOrder.Ascendant;
 
@@ -762,7 +762,7 @@ public partial class DataGrid
 
         this._headerView.Children.Clear();
         this._headerView.ColumnDefinitions.Clear();
-        this.sortingOrders.Clear();
+        this._sortingOrders.Clear();
 
         this._headerView.Padding = new(this.BorderThickness.Left, this.BorderThickness.Top, this.BorderThickness.Right, 0);
         this._headerView.ColumnSpacing = this.BorderThickness.HorizontalThickness;
@@ -787,7 +787,7 @@ public partial class DataGrid
                 Grid.SetColumn(cell, i);
                 this._headerView.Children.Add(cell);
 
-                this.sortingOrders.Add(i, SortingOrder.None);
+                this._sortingOrders.Add(i, SortingOrder.None);
             }
         }
     }

--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -18,25 +18,25 @@ public partial class DataGrid
 
     public event EventHandler<SelectionChangedEventArgs> ItemSelected
     {
-        add => this._itemSelectedEventManager.AddEventHandler(value);
-        remove => this._itemSelectedEventManager.RemoveEventHandler(value);
+        add => _itemSelectedEventManager.AddEventHandler(value);
+        remove => _itemSelectedEventManager.RemoveEventHandler(value);
     }
 
     private readonly WeakEventManager _refreshingEventManager = new();
 
     public event EventHandler Refreshing
     {
-        add => this._refreshingEventManager.AddEventHandler(value);
-        remove => this._refreshingEventManager.RemoveEventHandler(value);
+        add => _refreshingEventManager.AddEventHandler(value);
+        remove => _refreshingEventManager.RemoveEventHandler(value);
     }
 
     #region ctor
 
     public DataGrid()
     {
-        this.InitializeComponent();
+        InitializeComponent();
 
-        this._sortingOrders = new();
+        _sortingOrders = new();
     }
 
     #endregion ctor
@@ -45,12 +45,12 @@ public partial class DataGrid
 
     private void SortItems(SortData sortData)
     {
-        if (this.InternalItems == null || sortData.Index >= this.Columns.Count || !this.Columns[sortData.Index].SortingEnabled)
+        if (InternalItems == null || sortData.Index >= Columns.Count || !Columns[sortData.Index].SortingEnabled)
         {
             return;
         }
 
-        var column = this.Columns[sortData.Index];
+        var column = Columns[sortData.Index];
         var order = sortData.Order;
 
         if (column.PropertyName == null)
@@ -63,12 +63,12 @@ public partial class DataGrid
             throw new InvalidOperationException($"{column.PropertyName} column is not sortable");
         }
 
-        if (!this.IsSortable)
+        if (!IsSortable)
         {
             throw new InvalidOperationException("DataGrid is not sortable");
         }
 
-        var items = this.InternalItems;
+        var items = InternalItems;
 
         switch (order)
         {
@@ -82,25 +82,25 @@ public partial class DataGrid
                 break;
         }
 
-        for (var i = 0; i < this.Columns.Count; i++)
+        for (var i = 0; i < Columns.Count; i++)
         {
             if (i != sortData.Index)
             {
-                this._sortingOrders[i] = SortingOrder.None;
-                this.Columns[i].SortingIconContainer.IsVisible = false;
+                _sortingOrders[i] = SortingOrder.None;
+                Columns[i].SortingIconContainer.IsVisible = false;
             }
             else
             {
-                this.Columns[i].SortingIconContainer.IsVisible = true;
+                Columns[i].SortingIconContainer.IsVisible = true;
             }
         }
 
-        this._internalItems = items;
+        _internalItems = items;
 
-        this._sortingOrders[sortData.Index] = order;
-        this.SortedColumnIndex = sortData;
+        _sortingOrders[sortData.Index] = order;
+        SortedColumnIndex = sortData;
 
-        this._collectionView.ItemsSource = this._internalItems;
+        _collectionView.ItemsSource = _internalItems;
     }
 
     #endregion Sorting methods
@@ -113,7 +113,7 @@ public partial class DataGrid
     /// <param name="item">Item to scroll</param>
     /// <param name="position">Position of the row in screen</param>
     /// <param name="animated">animated</param>
-    public void ScrollTo(object item, ScrollToPosition position, bool animated = true) => this._collectionView.ScrollTo(item, position: position, animate: animated);
+    public void ScrollTo(object item, ScrollToPosition position, bool animated = true) => _collectionView.ScrollTo(item, position: position, animate: animated);
 
     #endregion Methods
 
@@ -225,10 +225,10 @@ public partial class DataGrid
     {
         if (sender is IEnumerable items)
         {
-            this.InternalItems = new List<object>(items.Cast<object>());
-            if (this.SelectedItem != null && !this.InternalItems.Contains(this.SelectedItem))
+            InternalItems = new List<object>(items.Cast<object>());
+            if (SelectedItem != null && !InternalItems.Contains(SelectedItem))
             {
-                this.SelectedItem = null;
+                SelectedItem = null;
             }
         }
     }
@@ -396,8 +396,8 @@ public partial class DataGrid
     /// </summary>
     public Color ActiveRowColor
     {
-        get => (Color)this.GetValue(ActiveRowColorProperty);
-        set => this.SetValue(ActiveRowColorProperty, value);
+        get => (Color)GetValue(ActiveRowColorProperty);
+        set => SetValue(ActiveRowColorProperty, value);
     }
 
     /// <summary>
@@ -406,8 +406,8 @@ public partial class DataGrid
     /// </summary>
     public Color HeaderBackground
     {
-        get => (Color)this.GetValue(HeaderBackgroundProperty);
-        set => this.SetValue(HeaderBackgroundProperty, value);
+        get => (Color)GetValue(HeaderBackgroundProperty);
+        set => SetValue(HeaderBackgroundProperty, value);
     }
 
     /// <summary>
@@ -416,8 +416,8 @@ public partial class DataGrid
     /// </summary>
     public Color BorderColor
     {
-        get => (Color)this.GetValue(BorderColorProperty);
-        set => this.SetValue(BorderColorProperty, value);
+        get => (Color)GetValue(BorderColorProperty);
+        set => SetValue(BorderColorProperty, value);
     }
 
     /// <summary>
@@ -425,8 +425,8 @@ public partial class DataGrid
     /// </summary>
     public IColorProvider RowsBackgroundColorPalette
     {
-        get => (IColorProvider)this.GetValue(RowsBackgroundColorPaletteProperty);
-        set => this.SetValue(RowsBackgroundColorPaletteProperty, value);
+        get => (IColorProvider)GetValue(RowsBackgroundColorPaletteProperty);
+        set => SetValue(RowsBackgroundColorPaletteProperty, value);
     }
 
     /// <summary>
@@ -434,8 +434,8 @@ public partial class DataGrid
     /// </summary>
     public IColorProvider RowsTextColorPalette
     {
-        get => (IColorProvider)this.GetValue(RowsTextColorPaletteProperty);
-        set => this.SetValue(RowsTextColorPaletteProperty, value);
+        get => (IColorProvider)GetValue(RowsTextColorPaletteProperty);
+        set => SetValue(RowsTextColorPaletteProperty, value);
     }
 
     /// <summary>
@@ -443,26 +443,26 @@ public partial class DataGrid
     /// </summary>
     public IEnumerable ItemsSource
     {
-        get => (IEnumerable)this.GetValue(ItemsSourceProperty);
-        set => this.SetValue(ItemsSourceProperty, value);
+        get => (IEnumerable)GetValue(ItemsSourceProperty);
+        set => SetValue(ItemsSourceProperty, value);
     }
 
     private IList<object>? _internalItems;
 
     internal IList<object>? InternalItems
     {
-        get => this._internalItems;
+        get => _internalItems;
         set
         {
-            this._internalItems = value;
+            _internalItems = value;
 
-            if (this.IsSortable && this.SortedColumnIndex != null)
+            if (IsSortable && SortedColumnIndex != null)
             {
-                this.SortItems(this.SortedColumnIndex);
+                SortItems(SortedColumnIndex);
             }
             else
             {
-                this._collectionView.ItemsSource = this._internalItems;
+                _collectionView.ItemsSource = _internalItems;
             }
         }
     }
@@ -472,8 +472,8 @@ public partial class DataGrid
     /// </summary>
     public List<DataGridColumn> Columns
     {
-        get => (List<DataGridColumn>)this.GetValue(ColumnsProperty);
-        set => this.SetValue(ColumnsProperty, value);
+        get => (List<DataGridColumn>)GetValue(ColumnsProperty);
+        set => SetValue(ColumnsProperty, value);
     }
 
     /// <summary>
@@ -482,8 +482,8 @@ public partial class DataGrid
     /// </summary>
     public double FontSize
     {
-        get => (double)this.GetValue(FontSizeProperty);
-        set => this.SetValue(FontSizeProperty, value);
+        get => (double)GetValue(FontSizeProperty);
+        set => SetValue(FontSizeProperty, value);
     }
 
     /// <summary>
@@ -492,8 +492,8 @@ public partial class DataGrid
     /// </summary>
     public string FontFamily
     {
-        get => (string)this.GetValue(FontFamilyProperty);
-        set => this.SetValue(FontFamilyProperty, value);
+        get => (string)GetValue(FontFamilyProperty);
+        set => SetValue(FontFamilyProperty, value);
     }
 
     /// <summary>
@@ -501,8 +501,8 @@ public partial class DataGrid
     /// </summary>
     public int RowHeight
     {
-        get => (int)this.GetValue(RowHeightProperty);
-        set => this.SetValue(RowHeightProperty, value);
+        get => (int)GetValue(RowHeightProperty);
+        set => SetValue(RowHeightProperty, value);
     }
 
     /// <summary>
@@ -510,8 +510,8 @@ public partial class DataGrid
     /// </summary>
     public int HeaderHeight
     {
-        get => (int)this.GetValue(HeaderHeightProperty);
-        set => this.SetValue(HeaderHeightProperty, value);
+        get => (int)GetValue(HeaderHeightProperty);
+        set => SetValue(HeaderHeightProperty, value);
     }
 
     /// <summary>
@@ -521,8 +521,8 @@ public partial class DataGrid
     /// </summary>
     public bool IsSortable
     {
-        get => (bool)this.GetValue(IsSortableProperty);
-        set => this.SetValue(IsSortableProperty, value);
+        get => (bool)GetValue(IsSortableProperty);
+        set => SetValue(IsSortableProperty, value);
     }
 
     /// <summary>
@@ -530,8 +530,8 @@ public partial class DataGrid
     /// </summary>
     public bool SelectionEnabled
     {
-        get => (bool)this.GetValue(SelectionEnabledProperty);
-        set => this.SetValue(SelectionEnabledProperty, value);
+        get => (bool)GetValue(SelectionEnabledProperty);
+        set => SetValue(SelectionEnabledProperty, value);
     }
 
     /// <summary>
@@ -539,8 +539,8 @@ public partial class DataGrid
     /// </summary>
     public object? SelectedItem
     {
-        get => this.GetValue(SelectedItemProperty);
-        set => this.SetValue(SelectedItemProperty, value);
+        get => GetValue(SelectedItemProperty);
+        set => SetValue(SelectedItemProperty, value);
     }
 
     /// <summary>
@@ -548,8 +548,8 @@ public partial class DataGrid
     /// </summary>
     public ICommand PullToRefreshCommand
     {
-        get => (ICommand)this.GetValue(PullToRefreshCommandProperty);
-        set => this.SetValue(PullToRefreshCommandProperty, value);
+        get => (ICommand)GetValue(PullToRefreshCommandProperty);
+        set => SetValue(PullToRefreshCommandProperty, value);
     }
 
     /// <summary>
@@ -557,8 +557,8 @@ public partial class DataGrid
     /// </summary>
     public bool IsRefreshing
     {
-        get => (bool)this.GetValue(IsRefreshingProperty);
-        set => this.SetValue(IsRefreshingProperty, value);
+        get => (bool)GetValue(IsRefreshingProperty);
+        set => SetValue(IsRefreshingProperty, value);
     }
 
     /// <summary>
@@ -566,8 +566,8 @@ public partial class DataGrid
     /// </summary>
     public bool RefreshingEnabled
     {
-        get => (bool)this.GetValue(RefreshingEnabledProperty);
-        set => this.SetValue(RefreshingEnabledProperty, value);
+        get => (bool)GetValue(RefreshingEnabledProperty);
+        set => SetValue(RefreshingEnabledProperty, value);
     }
 
     /// <summary>
@@ -575,8 +575,8 @@ public partial class DataGrid
     /// </summary>
     public Thickness BorderThickness
     {
-        get => (Thickness)this.GetValue(BorderThicknessProperty);
-        set => this.SetValue(BorderThicknessProperty, value);
+        get => (Thickness)GetValue(BorderThicknessProperty);
+        set => SetValue(BorderThicknessProperty, value);
     }
 
     /// <summary>
@@ -585,8 +585,8 @@ public partial class DataGrid
     /// </summary>
     public bool HeaderBordersVisible
     {
-        get => (bool)this.GetValue(HeaderBordersVisibleProperty);
-        set => this.SetValue(HeaderBordersVisibleProperty, value);
+        get => (bool)GetValue(HeaderBordersVisibleProperty);
+        set => SetValue(HeaderBordersVisibleProperty, value);
     }
 
     /// <summary>
@@ -594,8 +594,8 @@ public partial class DataGrid
     /// </summary>
     public SortData SortedColumnIndex
     {
-        get => (SortData)this.GetValue(SortedColumnIndexProperty);
-        set => this.SetValue(SortedColumnIndexProperty, value);
+        get => (SortData)GetValue(SortedColumnIndexProperty);
+        set => SetValue(SortedColumnIndexProperty, value);
     }
 
     /// <summary>
@@ -604,8 +604,8 @@ public partial class DataGrid
     /// </summary>
     public Style HeaderLabelStyle
     {
-        get => (Style)this.GetValue(HeaderLabelStyleProperty);
-        set => this.SetValue(HeaderLabelStyleProperty, value);
+        get => (Style)GetValue(HeaderLabelStyleProperty);
+        set => SetValue(HeaderLabelStyleProperty, value);
     }
 
     /// <summary>
@@ -613,8 +613,8 @@ public partial class DataGrid
     /// </summary>
     public Polygon SortIcon
     {
-        get => (Polygon)this.GetValue(SortIconProperty);
-        set => this.SetValue(SortIconProperty, value);
+        get => (Polygon)GetValue(SortIconProperty);
+        set => SetValue(SortIconProperty, value);
     }
 
     /// <summary>
@@ -623,8 +623,8 @@ public partial class DataGrid
     /// </summary>
     public Style SortIconStyle
     {
-        get => (Style)this.GetValue(SortIconStyleProperty);
-        set => this.SetValue(SortIconStyleProperty, value);
+        get => (Style)GetValue(SortIconStyleProperty);
+        set => SetValue(SortIconStyleProperty, value);
     }
 
     /// <summary>
@@ -632,8 +632,8 @@ public partial class DataGrid
     /// </summary>
     public View NoDataView
     {
-        get => (View)this.GetValue(NoDataViewProperty);
-        set => this.SetValue(NoDataViewProperty, value);
+        get => (View)GetValue(NoDataViewProperty);
+        set => SetValue(NoDataViewProperty, value);
     }
 
     #endregion Properties
@@ -645,27 +645,27 @@ public partial class DataGrid
     {
         base.OnParentSet();
 
-        if (this.SelectionEnabled)
+        if (SelectionEnabled)
         {
-            if (this.Parent is null)
+            if (Parent is null)
             {
-                this._collectionView.SelectionChanged -= this.OnSelectionChanged;
+                _collectionView.SelectionChanged -= OnSelectionChanged;
             }
             else
             {
-                this._collectionView.SelectionChanged += this.OnSelectionChanged;
+                _collectionView.SelectionChanged += OnSelectionChanged;
             }
         }
 
-        if (this.RefreshingEnabled)
+        if (RefreshingEnabled)
         {
-            if (this.Parent is null)
+            if (Parent is null)
             {
-                this._refreshView.Refreshing -= this.OnRefreshing;
+                _refreshView.Refreshing -= OnRefreshing;
             }
             else
             {
-                this._refreshView.Refreshing += this.OnRefreshing;
+                _refreshView.Refreshing += OnRefreshing;
             }
         }
     }
@@ -674,34 +674,34 @@ public partial class DataGrid
     protected override void OnBindingContextChanged()
     {
         base.OnBindingContextChanged();
-        this.InitHeaderView();
+        InitHeaderView();
     }
 
-    private void OnRefreshing(object? sender, EventArgs e) => this._refreshingEventManager.HandleEvent(this, e, nameof(Refreshing));
+    private void OnRefreshing(object? sender, EventArgs e) => _refreshingEventManager.HandleEvent(this, e, nameof(Refreshing));
 
     private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
-        this.SelectedItem = this._collectionView.SelectedItem;
+        SelectedItem = _collectionView.SelectedItem;
 
-        this._itemSelectedEventManager.HandleEvent(this, e, nameof(ItemSelected));
+        _itemSelectedEventManager.HandleEvent(this, e, nameof(ItemSelected));
     }
 
     internal void Reload()
     {
-        if (this._internalItems is not null)
+        if (_internalItems is not null)
         {
-            this.InternalItems = new List<object>(this._internalItems);
+            InternalItems = new List<object>(_internalItems);
         }
-        this.RefreshHeaderColumnWidths();
+        RefreshHeaderColumnWidths();
     }
 
     private void RefreshHeaderColumnWidths()
     {
-        for (var i = 0; i < this.Columns.Count; i++)
+        for (var i = 0; i < Columns.Count; i++)
         {
-            var column = this.Columns[i];
+            var column = Columns[i];
 
-            this._headerView.ColumnDefinitions[i] = column.ColumnDefinition;
+            _headerView.ColumnDefinitions[i] = column.ColumnDefinition;
         }
     }
 
@@ -712,13 +712,13 @@ public partial class DataGrid
     private View GetHeaderViewForColumn(DataGridColumn column, int index)
     {
         column.HeaderLabel.Style = column.HeaderLabelStyle ??
-                                   this.HeaderLabelStyle ?? (Style)this._headerView.Resources["HeaderDefaultStyle"];
+                                   HeaderLabelStyle ?? (Style)_headerView.Resources["HeaderDefaultStyle"];
 
-        if (this.IsSortable && column.IsSortable(this) && column.SortingEnabled)
+        if (IsSortable && column.IsSortable(this) && column.SortingEnabled)
         {
-            column.SortingIcon.Style = this.SortIconStyle ?? (Style)this._headerView.Resources["SortIconStyle"];
-            column.SortingIconContainer.HeightRequest = this.HeaderHeight * 0.3;
-            column.SortingIconContainer.WidthRequest = this.HeaderHeight * 0.3;
+            column.SortingIcon.Style = SortIconStyle ?? (Style)_headerView.Resources["SortIconStyle"];
+            column.SortingIconContainer.HeightRequest = HeaderHeight * 0.3;
+            column.SortingIconContainer.WidthRequest = HeaderHeight * 0.3;
 
             var grid = new Grid
             {
@@ -736,11 +736,11 @@ public partial class DataGrid
                     {
                         Command = new Command(() =>
                         {
-                            var order = this._sortingOrders[index] == SortingOrder.Ascendant
+                            var order = _sortingOrders[index] == SortingOrder.Ascendant
                                 ? SortingOrder.Descendant
                                 : SortingOrder.Ascendant;
 
-                            this.SortedColumnIndex = new(index, order);
+                            SortedColumnIndex = new(index, order);
                         }, () => column.SortingEnabled)
                     }
                 }
@@ -758,47 +758,47 @@ public partial class DataGrid
 
     private void InitHeaderView()
     {
-        this.SetColumnsBindingContext();
+        SetColumnsBindingContext();
 
-        this._headerView.Children.Clear();
-        this._headerView.ColumnDefinitions.Clear();
-        this._sortingOrders.Clear();
+        _headerView.Children.Clear();
+        _headerView.ColumnDefinitions.Clear();
+        _sortingOrders.Clear();
 
-        this._headerView.Padding = new(this.BorderThickness.Left, this.BorderThickness.Top, this.BorderThickness.Right, 0);
-        this._headerView.ColumnSpacing = this.BorderThickness.HorizontalThickness;
+        _headerView.Padding = new(BorderThickness.Left, BorderThickness.Top, BorderThickness.Right, 0);
+        _headerView.ColumnSpacing = BorderThickness.HorizontalThickness;
 
-        if (this.Columns != null)
+        if (Columns != null)
         {
-            for (var i = 0; i < this.Columns.Count; i++)
+            for (var i = 0; i < Columns.Count; i++)
             {
-                var col = this.Columns[i];
+                var col = Columns[i];
 
                 col.ColumnDefinition ??= new(col.Width);
 
-                this._headerView.ColumnDefinitions.Add(col.ColumnDefinition);
+                _headerView.ColumnDefinitions.Add(col.ColumnDefinition);
 
-                var cell = this.GetHeaderViewForColumn(col, i);
+                var cell = GetHeaderViewForColumn(col, i);
 
-                cell.SetBinding(BackgroundColorProperty, new Binding(nameof(this.HeaderBackground), source: this));
+                cell.SetBinding(BackgroundColorProperty, new Binding(nameof(HeaderBackground), source: this));
 
                 cell.SetBinding(IsVisibleProperty,
                     new Binding(nameof(col.IsVisible), BindingMode.OneWay, source: col));
 
                 Grid.SetColumn(cell, i);
-                this._headerView.Children.Add(cell);
+                _headerView.Children.Add(cell);
 
-                this._sortingOrders.Add(i, SortingOrder.None);
+                _sortingOrders.Add(i, SortingOrder.None);
             }
         }
     }
 
     private void SetColumnsBindingContext()
     {
-        if (this.Columns != null)
+        if (Columns != null)
         {
-            foreach (var c in this.Columns)
+            foreach (var c in Columns)
             {
-                c.BindingContext = this.BindingContext;
+                c.BindingContext = BindingContext;
             }
         }
     }

--- a/Maui.DataGrid/DataGridColumn.cs
+++ b/Maui.DataGrid/DataGridColumn.cs
@@ -14,9 +14,9 @@ public sealed class DataGridColumn : BindableObject, IDefinition
 
     public DataGridColumn()
     {
-        this.HeaderLabel = new();
-        this.SortingIcon = new();
-        this.SortingIconContainer = new ContentView
+        HeaderLabel = new();
+        SortingIcon = new();
+        SortingIconContainer = new ContentView
         {
             IsVisible = false,
             Content = SortingIcon,
@@ -29,11 +29,11 @@ public sealed class DataGridColumn : BindableObject, IDefinition
 
     public event EventHandler SizeChanged
     {
-        add => this.sizeChangedEventManager.AddEventHandler(value);
-        remove => this.sizeChangedEventManager.RemoveEventHandler(value);
+        add => sizeChangedEventManager.AddEventHandler(value);
+        remove => sizeChangedEventManager.RemoveEventHandler(value);
     }
 
-    private void OnSizeChanged() => this.sizeChangedEventManager.HandleEvent(this, EventArgs.Empty, string.Empty);
+    private void OnSizeChanged() => sizeChangedEventManager.HandleEvent(this, EventArgs.Empty, string.Empty);
 
     #region Bindable Properties
 
@@ -110,15 +110,15 @@ public sealed class DataGridColumn : BindableObject, IDefinition
     {
         get
         {
-            if (!this.IsVisible)
+            if (!IsVisible)
             {
-                return this.invisibleColumnDefinition;
+                return invisibleColumnDefinition;
             }
 
-            return this.columnDefinition;
+            return columnDefinition;
         }
 
-        internal set => this.columnDefinition = value;
+        internal set => columnDefinition = value;
     }
 
     /// <summary>
@@ -127,11 +127,11 @@ public sealed class DataGridColumn : BindableObject, IDefinition
     [TypeConverter(typeof(GridLengthTypeConverter))]
     public GridLength Width
     {
-        get => (GridLength)this.GetValue(WidthProperty);
+        get => (GridLength)GetValue(WidthProperty);
         set
         {
-            this.SetValue(WidthProperty, value);
-            this.ColumnDefinition = new(value);
+            SetValue(WidthProperty, value);
+            ColumnDefinition = new(value);
         }
     }
 
@@ -140,8 +140,8 @@ public sealed class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public string Title
     {
-        get => (string)this.GetValue(TitleProperty);
-        set => this.SetValue(TitleProperty, value);
+        get => (string)GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
     }
 
     /// <summary>
@@ -159,8 +159,8 @@ public sealed class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public FormattedString FormattedTitle
     {
-        get => (string)this.GetValue(FormattedTitleProperty);
-        set => this.SetValue(FormattedTitleProperty, value);
+        get => (string)GetValue(FormattedTitleProperty);
+        set => SetValue(FormattedTitleProperty, value);
     }
 
     /// <summary>
@@ -168,8 +168,8 @@ public sealed class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public string PropertyName
     {
-        get => (string)this.GetValue(PropertyNameProperty);
-        set => this.SetValue(PropertyNameProperty, value);
+        get => (string)GetValue(PropertyNameProperty);
+        set => SetValue(PropertyNameProperty, value);
     }
 
     /// <summary>
@@ -177,8 +177,8 @@ public sealed class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public bool IsVisible
     {
-        get => (bool)this.GetValue(IsVisibleProperty);
-        set => this.SetValue(IsVisibleProperty, value);
+        get => (bool)GetValue(IsVisibleProperty);
+        set => SetValue(IsVisibleProperty, value);
     }
 
     /// <summary>
@@ -186,8 +186,8 @@ public sealed class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public string StringFormat
     {
-        get => (string)this.GetValue(StringFormatProperty);
-        set => this.SetValue(StringFormatProperty, value);
+        get => (string)GetValue(StringFormatProperty);
+        set => SetValue(StringFormatProperty, value);
     }
 
     /// <summary>
@@ -195,8 +195,8 @@ public sealed class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public DataTemplate CellTemplate
     {
-        get => (DataTemplate)this.GetValue(CellTemplateProperty);
-        set => this.SetValue(CellTemplateProperty, value);
+        get => (DataTemplate)GetValue(CellTemplateProperty);
+        set => SetValue(CellTemplateProperty, value);
     }
 
     internal Polygon SortingIcon { get; }
@@ -208,8 +208,8 @@ public sealed class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public LineBreakMode LineBreakMode
     {
-        get => (LineBreakMode)this.GetValue(LineBreakModeProperty);
-        set => this.SetValue(LineBreakModeProperty, value);
+        get => (LineBreakMode)GetValue(LineBreakModeProperty);
+        set => SetValue(LineBreakModeProperty, value);
     }
 
     /// <summary>
@@ -217,8 +217,8 @@ public sealed class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public LayoutOptions HorizontalContentAlignment
     {
-        get => (LayoutOptions)this.GetValue(HorizontalContentAlignmentProperty);
-        set => this.SetValue(HorizontalContentAlignmentProperty, value);
+        get => (LayoutOptions)GetValue(HorizontalContentAlignmentProperty);
+        set => SetValue(HorizontalContentAlignmentProperty, value);
     }
 
     /// <summary>
@@ -226,8 +226,8 @@ public sealed class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public LayoutOptions VerticalContentAlignment
     {
-        get => (LayoutOptions)this.GetValue(VerticalContentAlignmentProperty);
-        set => this.SetValue(VerticalContentAlignmentProperty, value);
+        get => (LayoutOptions)GetValue(VerticalContentAlignmentProperty);
+        set => SetValue(VerticalContentAlignmentProperty, value);
     }
 
     /// <summary>
@@ -236,8 +236,8 @@ public sealed class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public bool SortingEnabled
     {
-        get => (bool)this.GetValue(SortingEnabledProperty);
-        set => this.SetValue(SortingEnabledProperty, value);
+        get => (bool)GetValue(SortingEnabledProperty);
+        set => SetValue(SortingEnabledProperty, value);
     }
 
     /// <summary>
@@ -247,27 +247,27 @@ public sealed class DataGridColumn : BindableObject, IDefinition
     /// <param name="dataGrid"></param>
     public bool IsSortable(DataGrid dataGrid)
     {
-        if (this.isSortable is not null)
+        if (isSortable is not null)
         {
-            return this.isSortable.Value;
+            return isSortable.Value;
         }
 
         try
         {
             var listItemType = dataGrid.ItemsSource.GetType().GetGenericArguments().Single();
-            var columnDataType = listItemType.GetProperty(this.PropertyName)?.PropertyType;
+            var columnDataType = listItemType.GetProperty(PropertyName)?.PropertyType;
 
             if (columnDataType is not null)
             {
-                this.isSortable = typeof(IComparable).IsAssignableFrom(columnDataType);
+                isSortable = typeof(IComparable).IsAssignableFrom(columnDataType);
             }
         }
         catch
         {
-            this.isSortable = false;
+            isSortable = false;
         }
 
-        return this.isSortable ?? false;
+        return isSortable ?? false;
     }
 
     /// <summary>
@@ -275,8 +275,8 @@ public sealed class DataGridColumn : BindableObject, IDefinition
     /// </summary>
     public Style HeaderLabelStyle
     {
-        get => (Style)this.GetValue(HeaderLabelStyleProperty);
-        set => this.SetValue(HeaderLabelStyleProperty, value);
+        get => (Style)GetValue(HeaderLabelStyleProperty);
+        set => SetValue(HeaderLabelStyleProperty, value);
     }
 
     #endregion properties

--- a/Maui.DataGrid/DataGridRow.cs
+++ b/Maui.DataGrid/DataGridRow.cs
@@ -17,8 +17,8 @@ internal sealed class DataGridRow : Grid
 
     public DataGrid DataGrid
     {
-        get => (DataGrid)this.GetValue(DataGridProperty);
-        set => this.SetValue(DataGridProperty, value);
+        get => (DataGrid)GetValue(DataGridProperty);
+        set => SetValue(DataGridProperty, value);
     }
 
     #endregion properties
@@ -35,22 +35,22 @@ internal sealed class DataGridRow : Grid
 
     private void CreateView()
     {
-        this.ColumnDefinitions.Clear();
-        this.Children.Clear();
+        ColumnDefinitions.Clear();
+        Children.Clear();
 
-        this.BackgroundColor = this.DataGrid.BorderColor;
+        BackgroundColor = DataGrid.BorderColor;
 
-        var borderThickness = this.DataGrid.BorderThickness;
+        var borderThickness = DataGrid.BorderThickness;
 
-        this.Padding = new(borderThickness.Left, borderThickness.Top, borderThickness.Right, 0);
-        this.ColumnSpacing = borderThickness.HorizontalThickness;
-        this.Margin = new Thickness(0, 0, 0, borderThickness.Bottom); // Row Spacing
+        Padding = new(borderThickness.Left, borderThickness.Top, borderThickness.Right, 0);
+        ColumnSpacing = borderThickness.HorizontalThickness;
+        Margin = new Thickness(0, 0, 0, borderThickness.Bottom); // Row Spacing
 
-        for (var i = 0; i < this.DataGrid.Columns.Count; i++)
+        for (var i = 0; i < DataGrid.Columns.Count; i++)
         {
-            var col = this.DataGrid.Columns[i];
+            var col = DataGrid.Columns[i];
 
-            this.ColumnDefinitions.Add(col.ColumnDefinition);
+            ColumnDefinitions.Add(col.ColumnDefinition);
 
             View cell;
 
@@ -60,7 +60,7 @@ internal sealed class DataGridRow : Grid
                 if (col.PropertyName != null)
                 {
                     cell.SetBinding(BindingContextProperty,
-                        new Binding(col.PropertyName, source: this.BindingContext));
+                        new Binding(col.PropertyName, source: BindingContext));
                 }
             }
             else
@@ -78,40 +78,40 @@ internal sealed class DataGridRow : Grid
                 cell.SetBinding(Label.TextProperty,
                     new Binding(col.PropertyName, BindingMode.Default, stringFormat: col.StringFormat));
                 cell.SetBinding(Label.FontSizeProperty,
-                    new Binding(DataGrid.FontSizeProperty.PropertyName, BindingMode.Default, source: this.DataGrid));
+                    new Binding(DataGrid.FontSizeProperty.PropertyName, BindingMode.Default, source: DataGrid));
                 cell.SetBinding(Label.FontFamilyProperty,
-                    new Binding(DataGrid.FontFamilyProperty.PropertyName, BindingMode.Default, source: this.DataGrid));
+                    new Binding(DataGrid.FontFamilyProperty.PropertyName, BindingMode.Default, source: DataGrid));
             }
 
             cell.SetBinding(IsVisibleProperty,
                 new Binding(nameof(col.IsVisible), BindingMode.OneWay, source: col));
 
             SetColumn((BindableObject)cell, i);
-            this.Children.Add(cell);
+            Children.Add(cell);
         }
 
-        this.UpdateBackgroundColor();
+        UpdateBackgroundColor();
     }
 
     private void UpdateBackgroundColor()
     {
-        this._hasSelected = this.DataGrid?.SelectedItem == this.BindingContext;
-        var actualIndex = this.DataGrid?.InternalItems?.IndexOf(this.BindingContext) ?? -1;
+        _hasSelected = DataGrid?.SelectedItem == BindingContext;
+        var actualIndex = DataGrid?.InternalItems?.IndexOf(BindingContext) ?? -1;
         if (actualIndex > -1)
         {
-            this._bgColor =
-                this.DataGrid?.SelectionEnabled == true && this.DataGrid.SelectedItem != null && this.DataGrid.SelectedItem == this.BindingContext
-                    ? this.DataGrid.ActiveRowColor
-                    : this.DataGrid?.RowsBackgroundColorPalette.GetColor(actualIndex, this.BindingContext);
-            this._textColor = this.DataGrid?.RowsTextColorPalette.GetColor(actualIndex, this.BindingContext);
+            _bgColor =
+                DataGrid?.SelectionEnabled == true && DataGrid.SelectedItem != null && DataGrid.SelectedItem == BindingContext
+                    ? DataGrid.ActiveRowColor
+                    : DataGrid?.RowsBackgroundColorPalette.GetColor(actualIndex, BindingContext);
+            _textColor = DataGrid?.RowsTextColorPalette.GetColor(actualIndex, BindingContext);
 
-            this.ChangeColor(this._bgColor, this._textColor);
+            ChangeColor(_bgColor, _textColor);
         }
     }
 
     private void ChangeColor(Color? bgColor, Color? textColor)
     {
-        foreach (var v in this.Children)
+        foreach (var v in Children)
         {
             if (v is View view)
             {
@@ -129,7 +129,7 @@ internal sealed class DataGridRow : Grid
     protected override void OnBindingContextChanged()
     {
         base.OnBindingContextChanged();
-        this.CreateView();
+        CreateView();
     }
 
     /// <inheritdoc/>
@@ -137,32 +137,32 @@ internal sealed class DataGridRow : Grid
     {
         base.OnParentSet();
 
-        if (this.DataGrid.SelectionEnabled)
+        if (DataGrid.SelectionEnabled)
         {
-            if (this.Parent != null)
+            if (Parent != null)
             {
-                this.DataGrid.ItemSelected += this.DataGrid_ItemSelected;
+                DataGrid.ItemSelected += DataGrid_ItemSelected;
             }
             else
             {
-                this.DataGrid.ItemSelected -= this.DataGrid_ItemSelected;
+                DataGrid.ItemSelected -= DataGrid_ItemSelected;
             }
         }
     }
 
     private void DataGrid_ItemSelected(object? sender, SelectionChangedEventArgs e)
     {
-        if (this.DataGrid.SelectionEnabled)
+        if (DataGrid.SelectionEnabled)
         {
-            if (this._hasSelected)
+            if (_hasSelected)
             {
-                this.UpdateBackgroundColor();
+                UpdateBackgroundColor();
             }
             else if (e.CurrentSelection.Count > 0)
             {
-                if (e.CurrentSelection[^1] == this.BindingContext)
+                if (e.CurrentSelection[^1] == BindingContext)
                 {
-                    this.UpdateBackgroundColor();
+                    UpdateBackgroundColor();
                 }
             }
         }

--- a/Maui.DataGrid/DataGridRow.cs
+++ b/Maui.DataGrid/DataGridRow.cs
@@ -7,9 +7,9 @@ internal sealed class DataGridRow : Grid
 {
     #region Fields
 
-    private Color? bgColor;
-    private Color? textColor;
-    private bool hasSelected;
+    private Color? _bgColor;
+    private Color? _textColor;
+    private bool _hasSelected;
 
     #endregion Fields
 
@@ -67,8 +67,8 @@ internal sealed class DataGridRow : Grid
             {
                 cell = new Label
                 {
-                    TextColor = textColor,
-                    BackgroundColor = bgColor,
+                    TextColor = _textColor,
+                    BackgroundColor = _bgColor,
                     VerticalOptions = LayoutOptions.Fill,
                     HorizontalOptions = LayoutOptions.Fill,
                     VerticalTextAlignment = col.VerticalContentAlignment.ToTextAlignment(),
@@ -95,17 +95,17 @@ internal sealed class DataGridRow : Grid
 
     private void UpdateBackgroundColor()
     {
-        this.hasSelected = this.DataGrid?.SelectedItem == this.BindingContext;
+        this._hasSelected = this.DataGrid?.SelectedItem == this.BindingContext;
         var actualIndex = this.DataGrid?.InternalItems?.IndexOf(this.BindingContext) ?? -1;
         if (actualIndex > -1)
         {
-            this.bgColor =
+            this._bgColor =
                 this.DataGrid?.SelectionEnabled == true && this.DataGrid.SelectedItem != null && this.DataGrid.SelectedItem == this.BindingContext
                     ? this.DataGrid.ActiveRowColor
                     : this.DataGrid?.RowsBackgroundColorPalette.GetColor(actualIndex, this.BindingContext);
-            this.textColor = this.DataGrid?.RowsTextColorPalette.GetColor(actualIndex, this.BindingContext);
+            this._textColor = this.DataGrid?.RowsTextColorPalette.GetColor(actualIndex, this.BindingContext);
 
-            this.ChangeColor(this.bgColor, this.textColor);
+            this.ChangeColor(this._bgColor, this._textColor);
         }
     }
 
@@ -154,7 +154,7 @@ internal sealed class DataGridRow : Grid
     {
         if (this.DataGrid.SelectionEnabled)
         {
-            if (this.hasSelected)
+            if (this._hasSelected)
             {
                 this.UpdateBackgroundColor();
             }

--- a/Maui.DataGrid/PaletteCollection.cs
+++ b/Maui.DataGrid/PaletteCollection.cs
@@ -1,4 +1,4 @@
-﻿namespace Maui.DataGrid;
+namespace Maui.DataGrid;
 
 /// <summary>
 /// Creates PaletteCollection for row's visual. It repeats colors consecutively for rows.
@@ -11,5 +11,13 @@ public sealed class PaletteCollection : List<Color>, IColorProvider
     /// <param name="rowIndex">Index of the row based on DataSource</param>
     /// <param name="item">Item on the index</param>
     /// <returns>Color for the row</returns>
-    public Color GetColor(int rowIndex, object item) => this.Count > 0 ? this.ElementAt(rowIndex % this.Count) : Colors.White;
+    public Color GetColor(int rowIndex, object item)
+    {
+        if (this.Count > 0)
+        {
+            return this.ElementAt(rowIndex % this.Count);
+        }
+
+        return Colors.White;
+    }
 }

--- a/Maui.DataGrid/PaletteCollection.cs
+++ b/Maui.DataGrid/PaletteCollection.cs
@@ -13,9 +13,9 @@ public sealed class PaletteCollection : List<Color>, IColorProvider
     /// <returns>Color for the row</returns>
     public Color GetColor(int rowIndex, object item)
     {
-        if (this.Count > 0)
+        if (Count > 0)
         {
-            return this.ElementAt(rowIndex % this.Count);
+            return this.ElementAt(rowIndex % Count);
         }
 
         return Colors.White;

--- a/Maui.DataGrid/SortData.cs
+++ b/Maui.DataGrid/SortData.cs
@@ -19,7 +19,7 @@ public sealed class SortData
     {
         if (obj is SortData other)
         {
-            return other.Index == this.Index && other.Order == this.Order;
+            return other.Index == Index && other.Order == Order;
         }
 
         return false;
@@ -32,8 +32,8 @@ public sealed class SortData
 
     public SortData(int index, SortingOrder order)
     {
-        this.Index = index;
-        this.Order = order;
+        Index = index;
+        Order = order;
     }
 
     #endregion ctor


### PR DESCRIPTION
This reverses the EditorConfig rules for member qualification, underscore prefixes on fields, and expression-bodied members.