### PR TITLE
Fix #53

### DIFF
--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -327,8 +327,11 @@ public partial class DataGrid
         BindableProperty.Create(nameof(BorderThickness), typeof(Thickness), typeof(DataGrid), new Thickness(1),
             propertyChanged: (b, _, n) =>
             {
-                ((DataGrid)b)._headerView.ColumnSpacing = ((Thickness)n).HorizontalThickness / 2;
-                ((DataGrid)b)._headerView.Padding = ((Thickness)n).HorizontalThickness / 2;
+                var self = (DataGrid)b;
+                if (self.Columns != null && self.ItemsSource != null)
+                {
+                    self.Reload();
+                }
             });
 
     public static readonly BindableProperty HeaderBordersVisibleProperty =


### PR DESCRIPTION
The header and every row rely on the BorderThickness to set the padding, margins, and column spacing. If it is changed, everything needs to be reloaded just as it does when changing the color palette.

Fixes https://github.com/akgulebubekir/Maui.DataGrid/issues/53