### PR TITLE
Set CompressedLayout.IsHeadless where possible

### DIFF
--- a/Maui.DataGrid/DataGrid.xaml
+++ b/Maui.DataGrid/DataGrid.xaml
@@ -3,8 +3,9 @@
       xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
       xmlns:local="clr-namespace:Maui.DataGrid;assembly=Maui.DataGrid"
-      x:Class="Maui.DataGrid.DataGrid">
-    <Grid>
+      x:Class="Maui.DataGrid.DataGrid"
+      CompressedLayout.IsHeadless="True">
+    <Grid CompressedLayout.IsHeadless="True">
         <Grid.Resources>
             <ResourceDictionary>
                 <local:BoolToSelectionModeConverter x:Key="boolToSelectionMode" />

--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -1,4 +1,5 @@
 namespace Maui.DataGrid;
+
 using System.Collections;
 using System.Collections.Specialized;
 using System.Windows.Input;
@@ -717,7 +718,7 @@ public partial class DataGrid
         column.HeaderLabel.Style = column.HeaderLabelStyle ??
                                    HeaderLabelStyle ?? (Style)_headerView.Resources["HeaderDefaultStyle"];
 
-        if (IsSortable && column.IsSortable(this) && column.SortingEnabled)
+        if (IsSortable && column.SortingEnabled && column.IsSortable(this))
         {
             column.SortingIcon.Style = SortIconStyle ?? (Style)_headerView.Resources["SortIconStyle"];
             column.SortingIconContainer.HeightRequest = HeaderHeight * 0.3;

--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -52,7 +52,6 @@ public partial class DataGrid
         }
 
         var column = Columns[sortData.Index];
-        var order = sortData.Order;
 
         if (column.PropertyName == null)
         {
@@ -71,7 +70,7 @@ public partial class DataGrid
 
         var items = InternalItems;
 
-        switch (order)
+        switch (sortData.Order)
         {
             case SortingOrder.Ascendant:
                 items = items.OrderBy(x => ReflectionUtils.GetValueByPath(x, column.PropertyName)).ToList();
@@ -98,7 +97,7 @@ public partial class DataGrid
 
         _internalItems = items;
 
-        _sortingOrders[sortData.Index] = order;
+        _sortingOrders[sortData.Index] = sortData.Order;
         SortedColumnIndex = sortData;
 
         _collectionView.ItemsSource = _internalItems;


### PR DESCRIPTION
I feel confident that I placed it on elements that are safe to do this for, but it is still possible that it could be safely placed on other elements later.

See the issue for more explanation of the logic and caveats.

Fix https://github.com/akgulebubekir/Maui.DataGrid/issues/49