### PR TITLE
Important performance improvement

### DIFF
--- a/Maui.DataGrid/DataGridRow.cs
+++ b/Maui.DataGrid/DataGridRow.cs
@@ -26,8 +26,7 @@ internal sealed class DataGridRow : Grid
     #region Bindable Properties
 
     public static readonly BindableProperty DataGridProperty =
-        BindableProperty.Create(nameof(DataGrid), typeof(DataGrid), typeof(DataGridRow), null,
-            propertyChanged: (b, _, _) => ((DataGridRow)b).CreateView());
+        BindableProperty.Create(nameof(DataGrid), typeof(DataGrid), typeof(DataGridRow), null, BindingMode.OneTime);
 
     #endregion Bindable Properties
 


### PR DESCRIPTION
Every row was being calculated twice, because CreateView was called inside the OnBindingContextChanged event as well as the propertyChanged event of the DataGrid property.

However, since the bindable property for the DataGrid in the DataGridRow is meant to be a direct reference, bound only one time, and not exposed as part of the API, we don't have to worry about the property ever being updated. 