### PR TITLE
Use compiled bindings

### DIFF
--- a/Maui.DataGrid/DataGrid.xaml
+++ b/Maui.DataGrid/DataGrid.xaml
@@ -16,7 +16,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <Grid Grid.Row="0" x:Name="_headerView" HeightRequest="{Binding HeaderHeight, Source={x:Reference self}}">
+        <Grid Grid.Row="0" x:Name="_headerView" HeightRequest="{Binding HeaderHeight, Source={Reference self}}">
             <Grid.Resources>
                 <ResourceDictionary>
                     <!--Default Header Style-->
@@ -36,17 +36,17 @@
                 </ResourceDictionary>
             </Grid.Resources>
         </Grid>
-        <RefreshView Grid.Row="1" x:Name="_refreshView" Grid.RowSpan="2" Command="{Binding PullToRefreshCommand, Source={x:Reference self}}"
+        <RefreshView Grid.Row="1" x:Name="_refreshView" Grid.RowSpan="2" Command="{Binding PullToRefreshCommand, Source={Reference self}}"
                      IsRefreshing="{Binding IsRefreshing, Source={x:Reference self}, Mode=TwoWay}">
             <!-- Set all platforms to use MeasureFirstItem when this bug is resolved https://github.com/dotnet/maui/issues/7562 -->
-            <CollectionView x:Name="_collectionView" WidthRequest="{Binding WidthRequest, Source={x:Reference self}}"
-                            SelectedItem="{Binding SelectedItem, Source={x:Reference self}, Mode=TwoWay}"
+            <CollectionView x:Name="_collectionView" WidthRequest="{Binding WidthRequest, Source={Reference self}}"
+                            SelectedItem="{Binding SelectedItem, Source={Reference self}, Mode=TwoWay}"
                             ItemSizingStrategy="{OnPlatform Android=MeasureAllItems, Default=MeasureFirstItem}"
-                            SelectionMode="{Binding SelectionEnabled, Source={x:Reference self}, Converter={StaticResource boolToSelectionMode}}" >
+                            SelectionMode="{Binding SelectionEnabled, Source={Reference self}, Converter={StaticResource boolToSelectionMode}}" >
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
                         <local:DataGridRow DataGrid="{Reference self}"
-                                           HeightRequest="{Binding RowHeight, Source={x:Reference self}, Mode=OneTime}" />
+                                           HeightRequest="{Binding RowHeight, Source={Reference self}, Mode=OneTime}" />
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>

--- a/Maui.DataGrid/DataGrid.xaml
+++ b/Maui.DataGrid/DataGrid.xaml
@@ -4,6 +4,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
       xmlns:local="clr-namespace:Maui.DataGrid;assembly=Maui.DataGrid"
       x:Class="Maui.DataGrid.DataGrid"
+      x:DataType="local:DataGrid"
       CompressedLayout.IsHeadless="True">
     <Grid CompressedLayout.IsHeadless="True">
         <Grid.Resources>


### PR DESCRIPTION
Use x:DataType to ensure compiled XAML bindings, and improve IntelliSense within the XAML