### PR TITLE
Reduce bindings

### DIFF
--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -796,12 +796,14 @@ public partial class DataGrid
 
                 _headerView.ColumnDefinitions.Add(col.ColumnDefinition);
 
+                if (!col.IsVisible)
+                {
+                    continue;
+                }
+
                 col.HeaderView ??= GetHeaderViewForColumn(col, i);
 
                 col.HeaderView.SetBinding(BackgroundColorProperty, new Binding(nameof(HeaderBackground), source: this));
-
-                col.HeaderView.SetBinding(IsVisibleProperty,
-                    new Binding(nameof(col.IsVisible), BindingMode.OneWay, source: col));
 
                 Grid.SetColumn(col.HeaderView, i);
                 _headerView.Children.Add(col.HeaderView);

--- a/Maui.DataGrid/DataGridColumn.cs
+++ b/Maui.DataGrid/DataGridColumn.cs
@@ -67,8 +67,8 @@ public sealed class DataGridColumn : BindableObject, IDefinition
                 {
                     try
                     {
-                        var dataGrid = (DataGrid?)column.HeaderLabel.Parent?.Parent?.Parent?.Parent;
-                        dataGrid?.Reload();
+                        column.DataGrid ??= (DataGrid?)column.HeaderLabel.Parent?.Parent?.Parent?.Parent;
+                        column.DataGrid?.Reload();
                     }
                     catch { }
                     finally
@@ -112,6 +112,8 @@ public sealed class DataGridColumn : BindableObject, IDefinition
     #endregion Bindable Properties
 
     #region properties
+
+    internal DataGrid? DataGrid { get; set; }
 
     internal ColumnDefinition? ColumnDefinition
     {

--- a/Maui.DataGrid/DataGridRow.cs
+++ b/Maui.DataGrid/DataGridRow.cs
@@ -53,6 +53,11 @@ internal sealed class DataGridRow : Grid
 
             ColumnDefinitions.Add(col.ColumnDefinition);
 
+            if (!col.IsVisible)
+            {
+                continue;
+            }
+
             View cell;
 
             if (col.CellTemplate != null)
@@ -92,9 +97,6 @@ internal sealed class DataGridRow : Grid
                 cell.SetBinding(Label.FontFamilyProperty,
                     new Binding(DataGrid.FontFamilyProperty.PropertyName, BindingMode.Default, source: DataGrid));
             }
-
-            cell.SetBinding(IsVisibleProperty,
-                new Binding(nameof(col.IsVisible), BindingMode.OneWay, source: col));
 
             SetColumn((BindableObject)cell, i);
             Children.Add(cell);


### PR DESCRIPTION
Bindings in collection views are expensive, and we are reloading the entire data grid anyways whenever the IsVisible property changes. So we can just check that property instead of binding on it.