### PR TITLE
Disable refresh view when refreshing is disabled

### DIFF
--- a/Maui.DataGrid/DataGrid.xaml
+++ b/Maui.DataGrid/DataGrid.xaml
@@ -37,7 +37,7 @@
             </Grid.Resources>
         </Grid>
         <RefreshView Grid.Row="1" x:Name="_refreshView" Grid.RowSpan="2" Command="{Binding PullToRefreshCommand, Source={Reference self}}"
-                     IsRefreshing="{Binding IsRefreshing, Source={x:Reference self}, Mode=TwoWay}">
+                     IsRefreshing="{Binding IsRefreshing, Source={x:Reference self}, Mode=TwoWay}" IsEnabled="{Binding RefreshingEnabled, Source={Reference self}}">
             <!--  Remove ContentView when this pull request is merged https://github.com/dotnet/maui/pull/14302  -->
             <ContentView>
                 <!--  Set all platforms to use MeasureFirstItem when this bug is resolved https://github.com/dotnet/maui/issues/7562  -->


### PR DESCRIPTION
Disable the ability to pull to refresh if the `RefreshingEnabled` property is false.

Fixes https://github.com/akgulebubekir/Maui.DataGrid/issues/88