### PR TITLE
Fix border color property if set in Styles.xaml

### DIFF
--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -256,7 +256,7 @@ public partial class DataGrid
             propertyChanged: (b, _, n) =>
             {
                 var self = (DataGrid)b;
-                if (self.HeaderBordersVisible && n is Color color)
+                if (self._headerView != null && self.HeaderBordersVisible && n is Color color)
                 {
                     self._headerView.BackgroundColor = color;
                 }


### PR DESCRIPTION
Thanks for your previous help with issue #100 

Now in my case, I've set the BorderColor in the `Styles.xaml` default file. But it will crash the app because when initialising the component and styling it using implicitly (i.e. not using `Key` and only use `TargetType`), `_headerView` is still null. Since there's a precedent for a null check in`HeaderBackgroundProperty`, I've added a similar null check in `BorderColorProperty`. While I'm at it, I double-checked for other properties that requires null check, but I don't think so since a lot of them should be set after the components have been initialised anyway such as `self._refreshView`, not for styling.

Again, I'm still new with Maui in general, this is my first open-source PR, so I don't know what's the best practice here and if there's any more refactoring required.

Please let me know if there's any issue.

Cheers,
Will 