### PR TITLE
Fix binding errors

### DIFF
--- a/Maui.DataGrid/DataGridRow.cs
+++ b/Maui.DataGrid/DataGridRow.cs
@@ -163,7 +163,11 @@ internal sealed class DataGridRow : Grid
     protected override void OnBindingContextChanged()
     {
         base.OnBindingContextChanged();
-        CreateView();
+
+        if (BindingContext != DataGrid.BindingContext)
+        {
+            CreateView();
+        }
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
I noticed XAML binding errors at runtime, which means that the DataGrid was loading all the DataGrid rows twice. Once at first with the BindingContext of the parent DataGrid, and then once for the row.

That first load was completely wrong. This check should reduce runtime errors and cut in half the amount of view creation, while still preserving the ability to change the BindingContext.

But, it would eliminate one possible option, where one has an infinitely recursive ViewModel. That probably would always be wrong, anyways.