### PR TITLE
Make the layout sensible

### DIFF
--- a/Maui.DataGrid.Sample/MainPage.xaml
+++ b/Maui.DataGrid.Sample/MainPage.xaml
@@ -14,12 +14,15 @@
             <Button Text="Settings" WidthRequest="100" Clicked="OnSettingsClicked" />
         </Grid>
 
-        <dg:DataGrid Grid.Row="1" ItemsSource="{Binding Teams}" SelectionMode="{Binding SelectionMode}" SelectedItem="{Binding SelectedTeam}"
-                     RowHeight="70" HeaderHeight="50" BorderColor="{StaticResource GridBorderColor}" RowToEdit="{Binding TeamToEdit}"
+        <dg:DataGrid Grid.Row="1" ItemsSource="{Binding Teams}" SelectionMode="{Binding SelectionMode}"
+                     SelectedItem="{Binding SelectedTeam}" RowToEdit="{Binding TeamToEdit}"
+                     BorderColor="{StaticResource GridBorderColor}" BorderThickness="{Binding BorderThickness}"
                      HeaderBackground="{StaticResource GridHeaderBgColor}" HeaderBordersVisible="{Binding HeaderBordersVisible}"
-                     PullToRefreshCommand="{Binding Commands[Refresh]}" IsRefreshing="{Binding IsRefreshing}"
+                     BackgroundColor="{StaticResource GridBgColor}" ActiveRowColor="{StaticResource ActiveRowColor}" 
+                     FooterBackground="{StaticResource GridFooterBgColor}"
                      PaginationEnabled="{Binding PaginationEnabled}" PageSize="{Binding PageSize}"
-                     ActiveRowColor="{StaticResource ActiveRowColor}" FooterBackground="{StaticResource GridFooterBgColor}" x:Name="_dataGrid1">
+                     PullToRefreshCommand="{Binding Commands[Refresh]}" IsRefreshing="{Binding IsRefreshing}"
+                     RowHeight="70" HeaderHeight="50" x:Name="_dataGrid1">
             <dg:DataGrid.Columns>
                 <dg:DataGridColumn Title="Logo" PropertyName="Logo" SortingEnabled="False">
                     <dg:DataGridColumn.CellTemplate>

--- a/Maui.DataGrid.Sample/Resources/Styles/Colors.xaml
+++ b/Maui.DataGrid.Sample/Resources/Styles/Colors.xaml
@@ -45,4 +45,5 @@
     <Color x:Key="GridHeaderBgColor">#E0E6F8</Color>
     <Color x:Key="GridFooterBgColor">#E0E6F8</Color>
     <Color x:Key="GridBorderColor">#CCCCCC</Color>
+    <Color x:Key="GridBgColor">#CCCCCC</Color>
 </ResourceDictionary>

--- a/Maui.DataGrid.Sample/SettingsPopup.xaml
+++ b/Maui.DataGrid.Sample/SettingsPopup.xaml
@@ -22,6 +22,11 @@
                     <Label Text="Header Borders Visible?" TextColor="White" VerticalOptions="Center" />
                 </HorizontalStackLayout>
                 <HorizontalStackLayout Style="{StaticResource SampleContainerStyle}">
+                    <Stepper Minimum="0" Maximum="10" Value="{Binding BorderThicknessNumeric}"
+                             BackgroundColor="{OnPlatform WinUI=Gray}"/>
+                    <Label Text="Border Thickness" TextColor="White" VerticalOptions="Center" />
+                </HorizontalStackLayout>
+                <HorizontalStackLayout Style="{StaticResource SampleContainerStyle}">
                     <CheckBox IsChecked="{Binding WonColumnVisible}" />
                     <Label Text="Won Column" TextColor="White" VerticalOptions="Center" />
                 </HorizontalStackLayout>

--- a/Maui.DataGrid.Sample/ViewModels/MainViewModel.cs
+++ b/Maui.DataGrid.Sample/ViewModels/MainViewModel.cs
@@ -17,6 +17,7 @@ public class MainViewModel : ViewModelBase
         TeamColumnWidth = 70;
         SelectionMode = SelectionMode.Single;
         PageSize = 6;
+        BorderThicknessNumeric = 1;
 
         Commands.Add("CompleteEdit", new Command(CmdCompleteEdit));
         Commands.Add("Edit", new Command<Team>(CmdEdit));
@@ -56,6 +57,20 @@ public class MainViewModel : ViewModelBase
         get => GetValue<bool>();
         set => SetValue(value);
     }
+
+    public double BorderThicknessNumeric
+    {
+        get => GetValue<double>();
+        set
+        {
+            if (SetValue(value))
+            {
+                OnPropertyChanged(nameof(BorderThickness));
+            }
+        }
+    }
+
+    public Thickness BorderThickness => new(BorderThicknessNumeric);
 
     public ushort TeamColumnWidth
     {

--- a/Maui.DataGrid.Sample/ViewModels/ViewModelBase.cs
+++ b/Maui.DataGrid.Sample/ViewModels/ViewModelBase.cs
@@ -21,15 +21,17 @@ public abstract class ViewModelBase : INotifyPropertyChanged
         Commands = [];
     }
 
-    protected void SetValue(object value, [CallerMemberName] string propertyName = null)
+    protected bool SetValue(object value, [CallerMemberName] string propertyName = null)
     {
         if (_properties.TryGetValue(propertyName!, out var item) && item == value)
         {
-            return;
+            return false;
         }
 
         _properties[propertyName!] = value;
         OnPropertyChanged(propertyName);
+
+        return true;
     }
 
     protected T GetValue<T>([CallerMemberName] string propertyName = null)

--- a/Maui.DataGrid/DataGrid.xaml
+++ b/Maui.DataGrid/DataGrid.xaml
@@ -45,7 +45,7 @@
             <CollectionView
                     x:Name="_collectionView"
                     WidthRequest="{Binding WidthRequest, Source={Reference self}}"
-                    BackgroundColor="{Binding BorderColor, Source={Reference self}}"
+                    BackgroundColor="{Binding BackgroundColor, Source={Reference self}}"
                     SelectedItem="{Binding SelectedItem, Source={Reference self}, Mode=TwoWay}"
                     SelectedItems="{Binding SelectedItems, Source={Reference self}, Mode=TwoWay}"
                     ItemSizingStrategy="{Binding ItemSizingStrategy, Source={Reference self}}"

--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -1395,7 +1395,7 @@ public partial class DataGrid
             Grid.SetColumn(column.SortingIconContainer, 1);
         }
 
-        return new DataGridCell(cellContent, HeaderBackground);
+        return new DataGridCell(cellContent, HeaderBackground, column, false);
     }
 
     private void InitHeaderView()
@@ -1406,8 +1406,6 @@ public partial class DataGrid
         }
 
         SetColumnsBindingContext();
-
-        _headerView.Children.Clear();
 
         if (Columns == null)
         {
@@ -1440,12 +1438,28 @@ public partial class DataGrid
                 continue;
             }
 
-            col.HeaderView ??= CreateHeaderCell(col);
+            col.HeaderCell ??= CreateHeaderCell(col);
 
-            col.HeaderView.UpdateBindings(this, HeaderBordersVisible);
+            col.HeaderCell.UpdateBindings(this, HeaderBordersVisible);
 
-            Grid.SetColumn(col.HeaderView, i);
-            _headerView.Children.Add(col.HeaderView);
+            if (_headerView.Children.TryGetItem(i, out var existingCell))
+            {
+                if (existingCell is not DataGridCell cell)
+                {
+                    throw new InvalidDataException($"{nameof(DataGridRow)} should only contain {nameof(DataGridCell)}s");
+                }
+
+                if (cell.Column != col)
+                {
+                    Grid.SetColumn(col.HeaderCell, i);
+                }
+            }
+            else
+            {
+                Grid.SetColumn(col.HeaderCell, i);
+                _headerView.Children.Add(col.HeaderCell);
+            }
+
         }
 
         // Remove extra columns

--- a/Maui.DataGrid/DataGridCell.cs
+++ b/Maui.DataGrid/DataGridCell.cs
@@ -1,0 +1,55 @@
+namespace Maui.DataGrid;
+
+using Microsoft.Maui.Controls;
+
+/// <summary>
+/// Specifies each cell of the DataGrid.
+/// </summary>
+internal sealed class DataGridCell : Grid
+{
+    internal DataGridCell(View cellContent, Color? backgroundColor)
+    {
+        var colorfulCellContent = new ContentView
+        {
+            BackgroundColor = backgroundColor,
+            Content = cellContent,
+        };
+
+        Children.Add(colorfulCellContent);
+    }
+
+    internal void UpdateBindings(DataGrid dataGrid, bool bordersVisible = true)
+    {
+        // The DataGridCell is a grid, and the padding constitutes the cell's border
+        // And the Background constitutes the border color of the cell.
+
+        if (bordersVisible)
+        {
+            BackgroundColor = dataGrid.BorderColor;
+            Padding = dataGrid.BorderThickness;
+
+            SetBinding(BackgroundColorProperty, new Binding(nameof(DataGrid.BorderColor), source: dataGrid));
+            SetBinding(PaddingProperty, new Binding(nameof(DataGrid.BorderThickness), source: dataGrid));
+        }
+        else
+        {
+            Padding = 0;
+
+            RemoveBinding(BackgroundColorProperty);
+            RemoveBinding(PaddingProperty);
+        }
+    }
+
+    internal void UpdateCellColors(Color? bgColor, Color? textColor = null)
+    {
+        foreach (var cellContent in Children.OfType<ContentView>())
+        {
+            cellContent.BackgroundColor = bgColor;
+
+            if (cellContent.Content is Label label && textColor != null)
+            {
+                label.TextColor = textColor;
+            }
+        }
+    }
+}

--- a/Maui.DataGrid/DataGridCell.cs
+++ b/Maui.DataGrid/DataGridCell.cs
@@ -7,7 +7,8 @@ using Microsoft.Maui.Controls;
 /// </summary>
 internal sealed class DataGridCell : Grid
 {
-    internal DataGridCell(View cellContent, Color? backgroundColor)
+    internal DataGridCell(View cellContent, Color? backgroundColor, DataGridColumn column, bool isEditing)
+
     {
         var colorfulCellContent = new ContentView
         {
@@ -15,8 +16,18 @@ internal sealed class DataGridCell : Grid
             Content = cellContent,
         };
 
+        Content = cellContent;
+        Column = column;
+        IsEditing = isEditing;
+
         Children.Add(colorfulCellContent);
     }
+
+    public View Content { get; }
+
+    public DataGridColumn Column { get; }
+    public bool IsEditing { get; }
+
 
     internal void UpdateBindings(DataGrid dataGrid, bool bordersVisible = true)
     {

--- a/Maui.DataGrid/DataGridColumn.cs
+++ b/Maui.DataGrid/DataGridColumn.cs
@@ -199,7 +199,7 @@ public sealed class DataGridColumn : BindableObject, IDefinition
         set => _columnDefinition = value;
     }
 
-    internal View? HeaderView { get; set; }
+    internal DataGridCell? HeaderView { get; set; }
 
     internal TextAlignment VerticalTextAlignment => _verticalTextAlignment ??= VerticalContentAlignment.ToTextAlignment();
 

--- a/Maui.DataGrid/DataGridColumn.cs
+++ b/Maui.DataGrid/DataGridColumn.cs
@@ -199,7 +199,7 @@ public sealed class DataGridColumn : BindableObject, IDefinition
         set => _columnDefinition = value;
     }
 
-    internal DataGridCell? HeaderView { get; set; }
+    internal DataGridCell? HeaderCell { get; set; }
 
     internal TextAlignment VerticalTextAlignment => _verticalTextAlignment ??= VerticalContentAlignment.ToTextAlignment();
 

--- a/Maui.DataGrid/Extensions/ListExtensions.cs
+++ b/Maui.DataGrid/Extensions/ListExtensions.cs
@@ -1,0 +1,18 @@
+namespace Maui.DataGrid.Extensions;
+
+internal static class ListExtensions
+{
+    public static bool TryGetItem<T>(this IList<T> list, int index, out T? item)
+    {
+        if (index >= 0 && index < list.Count)
+        {
+            item = list[index];
+            return true;
+        }
+        else
+        {
+            item = default;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
The original way that the grid worked involved creating borders between cells by creating empty space, and then using the background color as the border color. That approach is quite counter-intuitive. 

This PR wraps all of the cells with their own border. Now everything is way easier to understand for both users and developers.

UPDATE: This branch is not entirely awful now. It scrolls pretty fast. It is a bit slower is on column reordering and column resizing with large numbers of records. But the main branch isn't great in that scenario either.

Fixes #120 