### PR TITLE
Change PaginationStepperStyle binding to self ref

### DIFF
--- a/Maui.DataGrid/DataGrid.xaml
+++ b/Maui.DataGrid/DataGrid.xaml
@@ -70,7 +70,7 @@
             <HorizontalStackLayout Grid.Column="2" VerticalOptions="Center">
                 <Label Text="Page:" Margin="0,0,5,0" VerticalTextAlignment="Center" TextColor="Black" />
                 <Label Text="{Binding PageNumber, Source={Reference self}}" VerticalTextAlignment="Center" TextColor="Black" />
-                <Stepper x:Name="_paginationStepper" Value="{Binding PageNumber, Source={Reference self}}" Style="{StaticResource PaginationStepperStyle}" Minimum="1" />
+                <Stepper x:Name="_paginationStepper" Value="{Binding PageNumber, Source={Reference self}}" Style="{Binding PaginationStepperStyle, Source={Reference self}}" Minimum="1" />
             </HorizontalStackLayout>
         </Grid>
     </Grid>


### PR DESCRIPTION
The `PaginationStepperStyle` binding in `DataGrid.xaml` is causing a runtime error because it is set to `StaticResource` and no style with that key exists.

This PR updates the binding to use the bindable property in the `DataGrid` class.