### PR TITLE
call Reload after DataGrid Loaded to fix initialization

### DIFF
--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -50,6 +50,11 @@ public partial class DataGrid
         {
             _collectionView.ItemsSource = InternalItems;
         }
+
+        this.Loaded += (sender, e) =>
+        {
+            Reload();
+        };
     }
 
     #endregion ctor

--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -51,7 +51,7 @@ public partial class DataGrid
             _collectionView.ItemsSource = InternalItems;
         }
 
-        this.Loaded += (sender, e) =>
+        Loaded += (sender, e) =>
         {
             Reload();
         };


### PR DESCRIPTION
The Reload method gets called approximately five times, but always before the DataGrid is loaded. As a result, some events were not initialized correctly. In the provided example project, the WonColumnVisible did not trigger an update. It was only after a ColumnChangeEvent (for instance, when a column was added or removed) that the Reload method was executed, and from that point on, the WonColumnVisible behavior started working as expected.