### PR TITLE
Silence StyleCop warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-    <NoWarn>$(NoWarn);CA2007;CS1591;NU1605;SA1600;SA1633</NoWarn>
+    <NoWarn>$(NoWarn);CA2007;CS1591;NU1605;SA1101;SA1124;SA1309;SA1600;SA1633</NoWarn>
 
     <Configurations>Debug;Release;Test</Configurations>
     <MauiVersion>8.0.61</MauiVersion>


### PR DESCRIPTION
I recently turned on lots of warnings to help ensure readability, code quality, and consistency. I fixed the uncontroversial warnings.

In this PR, the controversial warnings from before I am silencing, which should preserve most of the original stylistic feeling.

These are: [SA1101](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md), [SA1124](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1124.md), and [SA1309](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md)

The general concept behind SA1101 and SA1309, as described, is to make it explicit that you are calling a method of a particular instance, and that you are covertly passing "this" to non-static methods. It also allows better IntelliSense.

SA1124 recommends not using regions and provides an explanation for why. Regardless, the other element ordering rules which are being followed will help ensure consistent member ordering and readability, with or without regions.