### PR TITLE
Fix crash on .NET 9

### DIFF
--- a/Maui.DataGrid.Sample/MainPage.xaml
+++ b/Maui.DataGrid.Sample/MainPage.xaml
@@ -61,12 +61,12 @@
                 <dg:DataGridColumn PropertyName="." Width="0.75*">
                     <dg:DataGridColumn.CellTemplate>
                         <DataTemplate x:DataType="m:Team">
-                            <Button Text="Edit" BackgroundColor="LightSkyBlue" Command="{Binding BindingContext.Commands[Edit], Source={Reference self}}" CommandParameter="{Binding .}" />
+                            <Button Text="Edit" BackgroundColor="LightSkyBlue" Command="{Binding BindingContext.Commands[Edit], Source={Reference self}, x:DataType={x:Null}}" CommandParameter="{Binding .}" />
                         </DataTemplate>
                     </dg:DataGridColumn.CellTemplate>
                     <dg:DataGridColumn.EditCellTemplate>
                         <DataTemplate x:DataType="m:Team">
-                            <Button Text="Done" BackgroundColor="MediumSeaGreen" Command="{Binding BindingContext.Commands[CompleteEdit], Source={Reference self}}" CommandParameter="{Binding .}" />
+                            <Button Text="Done" BackgroundColor="MediumSeaGreen" Command="{Binding BindingContext.Commands[CompleteEdit], Source={Reference self}, x:DataType={x:Null}}" CommandParameter="{Binding .}" />
                         </DataTemplate>
                     </dg:DataGridColumn.EditCellTemplate>
                 </dg:DataGridColumn>

--- a/Maui.DataGrid/DataGrid.xaml
+++ b/Maui.DataGrid/DataGrid.xaml
@@ -50,7 +50,7 @@
                     ItemSizingStrategy="{Binding ItemSizingStrategy, Source={Reference self}}"
                     SelectionMode="{Binding SelectionMode, Source={Reference self}}">
                 <CollectionView.ItemTemplate>
-                    <DataTemplate x:DataType="x:Object">
+                    <DataTemplate x:DataType="{x:Null}">
                         <local:DataGridRow DataGrid="{Reference self}" RowToEdit="{Binding RowToEdit, Source={Reference self}}" HeightRequest="{Binding RowHeight, Source={Reference self}, Mode=OneTime}" />
                     </DataTemplate>
                 </CollectionView.ItemTemplate>


### PR DESCRIPTION
Fixes #200 

This isn't a great fix in that this library is still not trimming and aot compatible, but this gets it to at least not-crash in client builds. This library was already incompatible for trimming and aot as x:Object previously just forced reflection bindings anyways in .NET 8.