### PR TITLE
set MeasureFirstItem as default

### DIFF
--- a/Maui.DataGrid/DataGrid.xaml
+++ b/Maui.DataGrid/DataGrid.xaml
@@ -48,7 +48,6 @@
         <local:DataGridHeaderRow Grid.Row="0" x:Name="_headerRow" DataGrid="{Reference self}" HeightRequest="{Binding HeaderHeight, Source={Reference self}}" />
         <RefreshView Grid.Row="1" x:Name="_refreshView" Grid.RowSpan="2" Command="{Binding PullToRefreshCommand, Source={Reference self}}" CommandParameter="{Binding PullToRefreshCommandParameter, Source={Reference self}}"
                      RefreshColor="{Binding RefreshColor, Source={Reference self}}" IsRefreshing="{Binding IsRefreshing, Source={Reference self}, Mode=TwoWay}" IsEnabled="{Binding RefreshingEnabled, Source={Reference self}}">
-                <!--  Set all platforms to use MeasureFirstItem when this bug is resolved https://github.com/dotnet/maui/issues/7562  -->
             <CollectionView
                     x:Name="_collectionView"
                     BackgroundColor="{Binding BackgroundColor, Source={Reference self}}"

--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -81,7 +81,7 @@ public partial class DataGrid
     /// Gets or sets the ItemSizingStrategy for the data grid.
     /// </summary>
     public static readonly BindableProperty ItemSizingStrategyProperty =
-        BindablePropertyExtensions.Create<DataGrid, ItemSizingStrategy>(DeviceInfo.Platform == DevicePlatform.Android ? ItemSizingStrategy.MeasureAllItems : ItemSizingStrategy.MeasureFirstItem);
+        BindablePropertyExtensions.Create<DataGrid, ItemSizingStrategy>(ItemSizingStrategy.MeasureFirstItem);
 
     /// <summary>
     /// Gets or sets the row to edit.
@@ -767,7 +767,7 @@ public partial class DataGrid
 
     /// <summary>
     /// Gets or sets <see cref="ItemSizingStrategy"/>
-    /// Default Value is <see cref="ItemSizingStrategy.MeasureFirstItem"/>, except on Android.
+    /// Default Value is <see cref="ItemSizingStrategy.MeasureFirstItem"/>.
     /// </summary>
     public ItemSizingStrategy ItemSizingStrategy
     {


### PR DESCRIPTION
The referenced issue is solved: https://github.com/dotnet/maui/issues/7562

MeasureFirstItem should allow better performance, and for a data grid it makes sense that it should be the default since you will almost always want every row to be the same height.