### PR TITLE
Add localization support for pagination and # per page customization

### DIFF
--- a/Maui.DataGrid.Sample/MainPage.xaml
+++ b/Maui.DataGrid.Sample/MainPage.xaml
@@ -22,7 +22,7 @@
                      HeaderBackground="{StaticResource GridHeaderBgColor}" HeaderBordersVisible="{Binding HeaderBordersVisible}"
                      BackgroundColor="{StaticResource GridBgColor}" ActiveRowColor="{StaticResource ActiveRowColor}"
                      FooterBackground="{StaticResource GridFooterBgColor}" SortedColumnIndex="1"
-                     PaginationEnabled="{Binding PaginationEnabled}" PageSize="{Binding PageSize}"
+                     PaginationEnabled="{Binding PaginationEnabled}" PageSize="{Binding PageSize}" PageText="{Binding PaginationText}" PerPageText="{Binding PerPageText}"
                      PullToRefreshCommand="{Binding Commands[Refresh]}" IsRefreshing="{Binding IsRefreshing}"
                      RowHeight="70" HeaderHeight="75" x:Name="_dataGrid1"
                      RowTappedCommand="{Binding Commands[Tapped]}">

--- a/Maui.DataGrid.Sample/ViewModels/MainViewModel.cs
+++ b/Maui.DataGrid.Sample/ViewModels/MainViewModel.cs
@@ -22,6 +22,8 @@ internal sealed class MainViewModel : ViewModelBase
         SelectionMode = SelectionMode.Single;
         PageSize = 6;
         BorderThicknessNumeric = 2;
+        PaginationText = "Page: ";
+        PerPageText = "# per page: ";
 
         Commands.Add("CompleteEdit", new Command(CmdCompleteEdit));
         Commands.Add("Edit", new Command<Team>(CmdEdit));
@@ -102,6 +104,18 @@ internal sealed class MainViewModel : ViewModelBase
     public bool PaginationEnabled
     {
         get => GetValue<bool>();
+        set => SetValue(value);
+    }
+
+    public string PaginationText
+    {
+        get => GetValue<string>() ?? "Page:";
+        set => SetValue(value);
+    }
+
+    public string PerPageText
+    {
+        get => GetValue<string>() ?? "# per page:";
         set => SetValue(value);
     }
 

--- a/Maui.DataGrid/DataGrid.xaml
+++ b/Maui.DataGrid/DataGrid.xaml
@@ -69,11 +69,11 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             <HorizontalStackLayout VerticalOptions="Center" IsVisible="{Binding PageSizeVisible, Source={Reference self}}">
-                <Label Text="# per page:" Margin="5,0,0,0" VerticalTextAlignment="Center" TextColor="Black" />
+                <Label Text="{Binding PerPageText, Source={Reference self}}" Margin="5,0,0,0" VerticalTextAlignment="Center" TextColor="Black" />
                 <Picker ItemsSource="{Binding PageSizeList, Source={Reference self}, Mode=TwoWay}" SelectedItem="{Binding PageSize, Source={Reference self}}" TextColor="Black"  MinimumWidthRequest="50" ios:Picker.UpdateMode="WhenFinished"/>
             </HorizontalStackLayout>
             <HorizontalStackLayout Grid.Column="2" VerticalOptions="Center">
-                <Label Text="Page:" Margin="0,0,5,0" VerticalTextAlignment="Center" TextColor="Black" />
+                <Label Text="{Binding PageText, Source={Reference self}}" Margin="0,0,5,0" VerticalTextAlignment="Center" TextColor="Black" />
                 <Label Text="{Binding PageNumber, Source={Reference self}}" VerticalTextAlignment="Center" TextColor="Black" />
                 <Stepper x:Name="_paginationStepper" Value="{Binding PageNumber, Source={Reference self}}" Style="{Binding PaginationStepperStyle, Source={Reference self}}" Minimum="1" />
             </HorizontalStackLayout>

--- a/Maui.DataGrid/DataGrid.xaml.cs
+++ b/Maui.DataGrid/DataGrid.xaml.cs
@@ -206,6 +206,34 @@ public partial class DataGrid
             });
 
     /// <summary>
+    /// Gets or sets the text for the page label in the DataGrid.
+    /// </summary>
+    public static readonly BindableProperty PageTextProperty =
+        BindablePropertyExtensions.Create<DataGrid, string>(
+            defaultValue: "Page:",
+            propertyChanged: (b, _, _) =>
+            {
+                if (b is DataGrid self)
+                {
+                    self.OnPropertyChanged(nameof(PageText));
+                }
+            });
+
+    /// <summary>
+    /// Gets or sets the localized text for the per page label.
+    /// </summary>
+    public static readonly BindableProperty PerPageTextProperty =
+        BindablePropertyExtensions.Create<DataGrid, string>(
+            defaultValue: "# per page:",
+            propertyChanged: (b, _, _) =>
+            {
+                if (b is DataGrid self)
+                {
+                    self.OnPropertyChanged(nameof(PerPageText));
+                }
+            });
+
+    /// <summary>
     /// Gets or sets the page count for the DataGrid.
     /// </summary>
     public static readonly BindableProperty PageCountProperty =
@@ -1127,6 +1155,24 @@ public partial class DataGrid
                 PageNumber = value;
             }
         }
+    }
+
+    /// <summary>
+    /// Gets or sets the customized text for the 'Page' label in the pagination section.
+    /// </summary>
+    public string PageText
+    {
+        get => (string)GetValue(PageTextProperty);
+        set => SetValue(PageTextProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the customized text for the 'Per Page' label in the pagination section.
+    /// </summary>
+    public string PerPageText
+    {
+        get => (string)GetValue(PerPageTextProperty);
+        set => SetValue(PerPageTextProperty, value);
     }
 
     internal Style DefaultHeaderLabelStyle { get; }


### PR DESCRIPTION
- Added support for localization of the pagination text (e.g. "Page" and "# per page") in the DataGrid.
- Introduced new properties to allow developers to customize these labels for different languages.
- Tested using the sample project to ensure changes work smoothly with the pagination system.
-------------------------------------
**Notes**: This is my first contribution to a open source project. If there's anything i could improve or if any adjustments are needed, please let me know!