### PR TITLE
Fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ builder.ConfigureMauiHandlers(handlers =>
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=akgulebubekir/Maui.DataGrid&type=Date)](https://star-history.com/#akgulebubekir/Maui.DataGrid&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=akgulebubekir/Maui.DataGrid&type=Date)](https://star-history.dera.page/#akgulebubekir/Maui.DataGrid&Date)


### PR DESCRIPTION
The star history chart in the README stopped rendering because the underlying service relies on GitHub's stargazer API, which is no longer available to it. This change points the chart image and its link to a working alternative that serves the same data, so the repository's star history stays visible again.